### PR TITLE
MAINT: turn xsdata errors into skbot ParseError

### DIFF
--- a/skbot/ignition/sdformat/sdformat.py
+++ b/skbot/ignition/sdformat/sdformat.py
@@ -146,7 +146,9 @@ def loads(
     try:
         sdf_parser.from_string(sdf, bindings.Sdf)
     except ElementTree.ParseError as e:
-        raise ParseError("Invalid XML.") from e
+        raise ParseError("Invalid SDFormat XML.") from e
+    except XSDataParserError as e:
+        raise ParseError("Invalid SDFormat XML.") from e
 
     return sdf_parser.from_string(sdf, bindings.Sdf)
 


### PR DESCRIPTION
This will handle all errors starting with the next version of xsdata (it will start catching the etree error that we are catching explicitly)