### PR TITLE
MAINT: Refactor euler link

### DIFF
--- a/skbot/transform/utils3d.py
+++ b/skbot/transform/utils3d.py
@@ -104,7 +104,7 @@ class EulerRotation(AffineCompound):
         angles = np.moveaxis(angles, axis, 0)
         rotations = list()
         for idx, char in enumerate(sequence):
-            angle:np.ndarray = angles[idx, ...]
+            angle: np.ndarray = angles[idx, ...]
             if char in ["x", "X"]:
                 rotvec = np.array((1, 0, 0), dtype=np.float_)
             elif char in ["y", "Y"]:
@@ -113,7 +113,7 @@ class EulerRotation(AffineCompound):
                 rotvec = np.array((0, 0, 1), dtype=np.float_)
             else:
                 raise ValueError("Unknown axis '{char}' in rotation sequence.")
-            
+
             rotvec = np.broadcast_to(rotvec, (*angle.shape, 3))
             rotvec = np.moveaxis(rotvec, -1, axis)
             rot = RotvecRotation(rotvec, angle=angle, degrees=degrees, axis=axis)

--- a/skbot/transform/utils3d.py
+++ b/skbot/transform/utils3d.py
@@ -3,7 +3,7 @@ import numpy as np
 from numpy.typing import ArrayLike
 from scipy.spatial.transform import Rotation as scipy_rotation
 
-from .base import CompundLink, Link
+from .base import Link
 from .projections import PerspectiveProjection
 from .affine import AffineCompound, Translation, Rotation
 from ._utils import angle_between, vector_project
@@ -103,7 +103,8 @@ class EulerRotation(AffineCompound):
 
         angles = np.moveaxis(angles, axis, 0)
         rotations = list()
-        for char, angle in zip(sequence, angles):
+        for idx, char in enumerate(sequence):
+            angle:np.ndarray = angles[idx, ...]
             if char in ["x", "X"]:
                 rotvec = np.array((1, 0, 0), dtype=np.float_)
             elif char in ["y", "Y"]:
@@ -115,7 +116,6 @@ class EulerRotation(AffineCompound):
             
             rotvec = np.broadcast_to(rotvec, (*angle.shape, 3))
             rotvec = np.moveaxis(rotvec, -1, axis)
-            # angle = np.expand_dims(angle, -1)
             rot = RotvecRotation(rotvec, angle=angle, degrees=degrees, axis=axis)
             rotations.append(rot)
 

--- a/skbot/transform/utils3d.py
+++ b/skbot/transform/utils3d.py
@@ -3,9 +3,9 @@ import numpy as np
 from numpy.typing import ArrayLike
 from scipy.spatial.transform import Rotation as scipy_rotation
 
-from .base import Link
+from .base import CompundLink, Link
 from .projections import PerspectiveProjection
-from .affine import Translation, Rotation
+from .affine import AffineCompound, Translation, Rotation
 from ._utils import angle_between, vector_project
 
 
@@ -74,7 +74,7 @@ class RotvecRotation(Rotation):
         self.angle = angle
 
 
-class EulerRotation(RotvecRotation):
+class EulerRotation(AffineCompound):
     """Rotation based on Euler angles in 3D.
 
     Parameters
@@ -97,12 +97,35 @@ class EulerRotation(RotvecRotation):
     def __init__(
         self, sequence: str, angles: ArrayLike, *, degrees: bool = False, axis: int = -1
     ) -> None:
-        rot = scipy_rotation.from_euler(sequence, angles, degrees)
+        angles = np.asarray(angles)
+        if angles.ndim == 0:
+            angles = angles[None, ...]
 
-        rotvec = rot.as_rotvec()
-        angle = rot.magnitude()
+        angles = np.moveaxis(angles, axis, 0)
+        rotations = list()
+        for char, angle in zip(sequence, angles):
+            if char in ["x", "X"]:
+                rotvec = np.array((1, 0, 0), dtype=np.float_)
+            elif char in ["y", "Y"]:
+                rotvec = np.array((0, 1, 0), dtype=np.float_)
+            elif char in ["z", "Z"]:
+                rotvec = np.array((0, 0, 1), dtype=np.float_)
+            else:
+                raise ValueError("Unknown axis '{char}' in rotation sequence.")
+            
+            rotvec = np.broadcast_to(rotvec, (*angle.shape, 3))
+            rotvec = np.moveaxis(rotvec, -1, axis)
+            # angle = np.expand_dims(angle, -1)
+            rot = RotvecRotation(rotvec, angle=angle, degrees=degrees, axis=axis)
+            rotations.append(rot)
 
-        super().__init__(rotvec, angle=angle, axis=axis)
+        if sequence.islower():
+            super().__init__(rotations)
+        elif sequence.isupper():
+            rotations = [x for x in reversed(rotations)]
+            super().__init__(rotations)
+        else:
+            raise ValueError("Can not mix intrinsic and extrinsic rotations.")
 
 
 class QuaternionRotation(RotvecRotation):
@@ -118,6 +141,13 @@ class QuaternionRotation(RotvecRotation):
         ``"xyzw"`` (default), i.e., scalar-last, or "wxyz", i.e., scalar-first.
     axis : int
         The axis along which to to compute. Default: -1.
+
+    Notes
+    -----
+    The current implementation uses scipy's rotation class. As such you are
+    limited to a single batch dimension. If this is to little, please open an
+    issue.
+
     """
 
     def __init__(

--- a/tests/transform/test_utils3d.py
+++ b/tests/transform/test_utils3d.py
@@ -122,6 +122,17 @@ def test_EulerRotation_vectorized(sequence, angles, degrees):
     assert np.allclose(result, expected)
 
 
+@pytest.mark.parametrize(
+    "sequence",
+    [
+        "XyZ",
+        "abc",
+        "xyw"
+    ],
+)
+def test_EulerRotation_invalid_sequence(sequence):
+    with pytest.raises(ValueError):
+        tf.EulerRotation(sequence, (0, 0, 0))
 
 @pytest.mark.parametrize(
     "sequence, quaternion",

--- a/tests/transform/test_utils3d.py
+++ b/tests/transform/test_utils3d.py
@@ -76,7 +76,7 @@ def test_vectorized_RotvecRotation(rotvec, angle, degrees, axis):
         ("xyz", (0, 0, 45), True),
         ("xyz", (0, 0, 90), True),
         ("XZY", (45, 180, 90), True),
-        ("XYZ", (np.pi/4, np.pi, np.pi/2), False),
+        ("XYZ", (np.pi / 4, np.pi, np.pi / 2), False),
     ],
 )
 def test_EulerRotation(sequence, angles, degrees):
@@ -96,16 +96,20 @@ def test_EulerRotation(sequence, angles, degrees):
 @pytest.mark.parametrize(
     "sequence, angles, degrees",
     [
-        ("xyz", ((0, 0, np.pi / 4),(0, 0, 0)), False),
+        ("xyz", ((0, 0, np.pi / 4), (0, 0, 0)), False),
         ("xyz", ((0, 0, 45),), True),
-        ("xyz", ((0, 0, 90),(0, 90, 0), (0, 0, 90)), True),
-        ("XZY", ((45, 180, 90),(20, 63, 176)), True),
-        ("XYZ", ((np.pi/4, np.pi, np.pi/2),(np.pi/6, 3/2*np.pi, 3*np.pi)), False),
+        ("xyz", ((0, 0, 90), (0, 90, 0), (0, 0, 90)), True),
+        ("XZY", ((45, 180, 90), (20, 63, 176)), True),
+        (
+            "XYZ",
+            ((np.pi / 4, np.pi, np.pi / 2), (np.pi / 6, 3 / 2 * np.pi, 3 * np.pi)),
+            False,
+        ),
     ],
 )
 def test_EulerRotation_vectorized(sequence, angles, degrees):
     angles = np.asarray(angles)
-    
+
     in_vectors = np.eye(3)
 
     rot = tf.EulerRotation(sequence, angles[None, ...], degrees=degrees)
@@ -124,15 +128,12 @@ def test_EulerRotation_vectorized(sequence, angles, degrees):
 
 @pytest.mark.parametrize(
     "sequence",
-    [
-        "XyZ",
-        "abc",
-        "xyw"
-    ],
+    ["XyZ", "abc", "xyw"],
 )
 def test_EulerRotation_invalid_sequence(sequence):
     with pytest.raises(ValueError):
         tf.EulerRotation(sequence, (0, 0, 0))
+
 
 @pytest.mark.parametrize(
     "sequence, quaternion",


### PR DESCRIPTION
Euler link now no longer depends on scipy.rotation. As a consequence it can

1. be used with 0 angles, e.g. EulerRotation("xyz", (0,0,0))
2. can be used with up to 2 batch dimensions (since it internally constructs three RotvecRotations, which still depend on scipy.rotation)