### PR TITLE
FEAT: AffineSpace link + Frame.X_between

### DIFF
--- a/skbot/ignition/sdformat/create_frame_graph.py
+++ b/skbot/ignition/sdformat/create_frame_graph.py
@@ -101,7 +101,7 @@ def create_frame_graph(sdf: str) -> Tuple[Dict[str, rtf.Frame], Dict[str, rtf.Li
         :func:``skbot.ignition.to_frame_graph`` instead. To find frames in the
         frame graph returned by ``to_frame_graph`` use
         :func:``skbot.transform.Frame.find_frame``. Links/Joints can be obtained
-        from :func:``skbot.transform.Frame.transform_chain``.
+        from :func:``skbot.transform.Frame.links_between``.
 
     Parameters
     ----------

--- a/skbot/ignition/sdformat/generic_sdf/base.py
+++ b/skbot/ignition/sdformat/generic_sdf/base.py
@@ -303,7 +303,7 @@ class Pose(ElementBase):
             `nested_model_A::nested_model_B::awesome_frame`.
     frame : str
         Old name for `relative_to`.
-        .. depreciated:: SDFormat v1.7
+        .. deprecated:: SDFormat v1.7
 
 
     """
@@ -327,7 +327,7 @@ class Pose(ElementBase):
 
     @property
     def frame(self):
-        warnings.warn("`Pose.frame` is depreciated. Use `Pose.relative_to` instead.")
+        warnings.warn("`Pose.frame` is deprecated. Use `Pose.relative_to` instead.")
         return self.relative_to
 
     @classmethod

--- a/skbot/ignition/sdformat/generic_sdf/camera.py
+++ b/skbot/ignition/sdformat/generic_sdf/camera.py
@@ -251,7 +251,7 @@ class Camera(ElementBase):
         parent_static = _scaffolding[parent_name]
         child_static = _scaffolding[child_name]
 
-        link = tf.CompundLink(parent_static.transform_chain(child_static))
+        link = tf.CompundLink(parent_static.links_between(child_static))
         link(parent, child)
 
         if self.sdf_version == "1.0":

--- a/skbot/ignition/sdformat/generic_sdf/camera.py
+++ b/skbot/ignition/sdformat/generic_sdf/camera.py
@@ -65,7 +65,7 @@ class Camera(ElementBase):
     frames : List[Frame]
         A list of frames of reference in which poses may be expressed.
 
-        .. depreciated:: SDFormat v1.7
+        .. deprecated:: SDFormat v1.7
             Use :attr:`Model.frame` instead.
         .. versionadded:: SDFormat v1.5
 
@@ -154,7 +154,7 @@ class Camera(ElementBase):
     @property
     def frames(self):
         warnings.warn(
-            "`Sensor.frames` is depreciated since SDF v1.7."
+            "`Sensor.frames` is deprecated since SDF v1.7."
             " Use `Model.frames` instead and set `Frame.attached_to` to the name of this link.",
             DeprecationWarning,
         )

--- a/skbot/ignition/sdformat/generic_sdf/frame.py
+++ b/skbot/ignition/sdformat/generic_sdf/frame.py
@@ -124,5 +124,5 @@ class Frame(ElementBase):
         parent_static = _scaffolding[parent_name]
         child_static = _scaffolding[child_name]
 
-        link = tf.CompundLink(parent_static.transform_chain(child_static))
+        link = tf.CompundLink(parent_static.links_between(child_static))
         link(parent, child)

--- a/skbot/ignition/sdformat/generic_sdf/joint.py
+++ b/skbot/ignition/sdformat/generic_sdf/joint.py
@@ -371,13 +371,13 @@ class Joint(ElementBase):
         joint_static = _scaffolding[joint_name]
         child_static = _scaffolding[child_name]
 
-        link = tf.CompundLink(parent_static.transform_chain(joint_static))
+        link = tf.CompundLink(parent_static.links_between(joint_static))
         link(parent, joint_parent)
 
         joint_link: tf.Link = self.to_tf_link(_scaffolding, shape=shape, axis=axis)
         joint_link(joint_child, joint_parent)
 
-        link = tf.CompundLink(joint_static.transform_chain(child_static))
+        link = tf.CompundLink(joint_static.links_between(child_static))
         link(joint_child, child)
 
         for el in chain(self._frames):
@@ -400,7 +400,7 @@ class Joint(ElementBase):
             parent_static = _scaffolding[parent_name]
             child_static = _scaffolding[child_name]
 
-            link = tf.CompundLink(parent_static.transform_chain(child_static))
+            link = tf.CompundLink(parent_static.links_between(child_static))
             link(parent, child)
 
             sensor.to_dynamic_graph(

--- a/skbot/ignition/sdformat/generic_sdf/joint.py
+++ b/skbot/ignition/sdformat/generic_sdf/joint.py
@@ -98,7 +98,7 @@ class Joint(ElementBase):
     frames : List[Frame]
         A list of frames of reference in which poses may be expressed.
 
-        .. depreciated:: SDFormat v1.7
+        .. deprecated:: SDFormat v1.7
             Use :attr:`Model.frame` instead.
         .. versionadded:: SDFormat v1.5
     sensors : List[Sensor]
@@ -110,7 +110,7 @@ class Joint(ElementBase):
     origin : Origin
         The joint's origin.
 
-        .. depreciated:: SDFormat v1.2
+        .. deprecated:: SDFormat v1.2
             Use ``Joint.pose`` instead.
 
     Attributes
@@ -181,7 +181,7 @@ class Joint(ElementBase):
         elif sdf_version == "1.0":
             self._origin = origin
         else:
-            warnings.warn("`origin` is depreciated. Use `pose` instead.")
+            warnings.warn("`origin` is deprecated. Use `pose` instead.")
             self._origin = origin
         if sdf_version == "1.0":
             self.pose = self._origin.pose
@@ -253,7 +253,7 @@ class Joint(ElementBase):
     @property
     def origin(self):
         warnings.warn(
-            "`Joint.origin` is depreciated since SDFormat v1.2."
+            "`Joint.origin` is deprecated since SDFormat v1.2."
             " Use `Joint.pose` instead.",
             DeprecationWarning,
         )
@@ -262,7 +262,7 @@ class Joint(ElementBase):
     @property
     def frames(self):
         warnings.warn(
-            "`Link.frames` is depreciated since SDF v1.7."
+            "`Link.frames` is deprecated since SDF v1.7."
             " Use `Model.frames` instead and set `Frame.attached_to`"
             " to the name of this joint.",
             DeprecationWarning,
@@ -522,7 +522,7 @@ class Joint(ElementBase):
         initial_position : float
             Default joint position for this joint axis.
 
-            .. depreciated:: SDFormat v1.8
+            .. deprecated:: SDFormat v1.8
                 Use `World.State` instead to set the initial position.
             .. versionadded:: SDFormat v1.6
         xyz: Union[str, Joint.Axis.Xyz]
@@ -536,7 +536,7 @@ class Joint(ElementBase):
             instead of joint frame. Provided for Gazebo compatibility (see
             https://github.com/osrf/gazebo/issue/494 ). Default is: ``False``.
 
-            .. depreciated:: SDFormat v1.7
+            .. deprecated:: SDFormat v1.7
                 Use :attr:`Joint.Axis.Xyz.expressed_in` instead.
             .. versionadded:: SDFormat v1.5
         dynamics: Joint.Axis.Dynamics
@@ -599,7 +599,7 @@ class Joint(ElementBase):
         @property
         def use_parent_model_frame(self):
             warnings.warn(
-                "`Joint.Axis.use_parent_model_frame` is depreciated."
+                "`Joint.Axis.use_parent_model_frame` is deprecated."
                 " Use `Joint.Axis.Xyz.expressed_in` instead."
             )
             return self._use_parent_model_frame

--- a/skbot/ignition/sdformat/generic_sdf/link.py
+++ b/skbot/ignition/sdformat/generic_sdf/link.py
@@ -387,7 +387,7 @@ class Link(ElementBase):
             parent_static = _scaffolding[parent_name]
             child_static = _scaffolding[child_name]
 
-            link = tf.CompundLink(parent_static.transform_chain(child_static))
+            link = tf.CompundLink(parent_static.links_between(child_static))
             link(parent, child)
 
         for frame in self._frames:
@@ -410,7 +410,7 @@ class Link(ElementBase):
             parent_static = _scaffolding[parent_name]
             child_static = _scaffolding[child_name]
 
-            link = tf.CompundLink(parent_static.transform_chain(child_static))
+            link = tf.CompundLink(parent_static.links_between(child_static))
             link(parent, child)
 
             sensor.to_dynamic_graph(

--- a/skbot/ignition/sdformat/generic_sdf/link.py
+++ b/skbot/ignition/sdformat/generic_sdf/link.py
@@ -93,17 +93,17 @@ class Link(ElementBase):
     origin : Origin
         The link's origin.
 
-        .. depreciated:: SDFormat v1.2
+        .. deprecated:: SDFormat v1.2
             Use `Link.pose` instead.
     damping : Link.Damping
         Exponential damping of the link's velocity.
 
-        .. depreciated:: SDFormat 1.2
+        .. deprecated:: SDFormat 1.2
             Use `Link.velocity_decay` instead.
     frames : List["Frame"]
         A list of frames of reference in which poses may be expressed.
 
-        .. depreciated:: SDFormat v1.7
+        .. deprecated:: SDFormat v1.7
             Use :attr:`Model.frame` instead.
         .. versionadded:: SDFormat v1.5
 
@@ -186,7 +186,7 @@ class Link(ElementBase):
         elif sdf_version == "1.0":
             self._origin = origin
         else:
-            warnings.warn("`origin` is depreciated. Use `pose` instead.")
+            warnings.warn("`origin` is deprecated. Use `pose` instead.")
             self._origin = origin
         if sdf_version == "1.0":
             self.pose = self._origin.pose
@@ -200,7 +200,7 @@ class Link(ElementBase):
         elif sdf_version == "1.0":
             self._damping = damping
         else:
-            warnings.warn("`damping` is depreciated. Use `velocity_decay` instead.")
+            warnings.warn("`damping` is deprecated. Use `velocity_decay` instead.")
             self._damping = damping
         if sdf_version == "1.0":
             self.velocity_decay = self._damping
@@ -263,7 +263,7 @@ class Link(ElementBase):
     @property
     def origin(self):
         warnings.warn(
-            "`Link.origin` is depreciated since SDF v1.7. Use `Link.pose` instead.",
+            "`Link.origin` is deprecated since SDF v1.7. Use `Link.pose` instead.",
             DeprecationWarning,
         )
         return self._origin
@@ -271,7 +271,7 @@ class Link(ElementBase):
     @property
     def damping(self):
         warnings.warn(
-            "`Link.daming` is depreciated since SDF v1.7."
+            "`Link.daming` is deprecated since SDF v1.7."
             " Use `Link.velocity_decay` instead.",
             DeprecationWarning,
         )
@@ -280,7 +280,7 @@ class Link(ElementBase):
     @property
     def frames(self):
         warnings.warn(
-            "`Link.frames` is depreciated since SDF v1.7."
+            "`Link.frames` is deprecated since SDF v1.7."
             " Use `Model.frames` instead and set `Frame.attached_to` to the name of this link.",
             DeprecationWarning,
         )

--- a/skbot/ignition/sdformat/generic_sdf/model.py
+++ b/skbot/ignition/sdformat/generic_sdf/model.py
@@ -107,7 +107,7 @@ class Model(ElementBase):
     origin : Origin
         The model's origin.
 
-        .. depreciated:: SDFormat v1.2
+        .. deprecated:: SDFormat v1.2
             Use ``Model.pose`` instead.
 
 
@@ -186,7 +186,7 @@ class Model(ElementBase):
         elif sdf_version == "1.0":
             self._origin = origin
         else:
-            warnings.warn("`origin` is depreciated. Use `Model.pose` instead.")
+            warnings.warn("`origin` is deprecated. Use `Model.pose` instead.")
             self._origin = origin
 
         if len(links) == 0 and sdf_version in ["1.0", "1.2", "1.3", "1.4"]:
@@ -248,7 +248,7 @@ class Model(ElementBase):
     @property
     def origin(self):
         warnings.warn(
-            "`Model.origin` is depreciated since SDFormat v1.2. Use `Model.pose` instead."
+            "`Model.origin` is deprecated since SDFormat v1.2. Use `Model.pose` instead."
         )
         return self._origin
 

--- a/skbot/ignition/sdformat/generic_sdf/model.py
+++ b/skbot/ignition/sdformat/generic_sdf/model.py
@@ -373,7 +373,7 @@ class Model(ElementBase):
             parent_static = _scaffolding[self.canonical_link]
         child = declared_frames["__model__"]
         child_static = _scaffolding["__model__"]
-        tf.CompundLink(parent_static.transform_chain(child_static))(parent, child)
+        tf.CompundLink(parent_static.links_between(child_static))(parent, child)
 
         for el in chain(self.frames, self.links, self.joints):
             el.to_dynamic_graph(

--- a/skbot/ignition/sdformat/generic_sdf/sdf.py
+++ b/skbot/ignition/sdformat/generic_sdf/sdf.py
@@ -38,24 +38,24 @@ class Sdf(ElementBase):
     version : str
         The SDFormat version.
     worlds : List[World]
-        .. depreciated:: SDFormat v1.8
+        .. deprecated:: SDFormat v1.8
             Worlds, models, lights, and/or actors can no longer be combined. Use
             `payload` instead.
         The worlds contained in this SDF.
     models : List[Model]
-        .. depreciated:: SDFormat v1.8
+        .. deprecated:: SDFormat v1.8
             Starting with SDFormat v1.8 only a single model is supported. Use the
             `model` kwarg instead.
 
         The models contained in this SDF.
     lights : List[Light]
-        .. depreciated:: SDFormat v1.8
+        .. deprecated:: SDFormat v1.8
             Starting with SDFormat v1.8 only a single light is supported. Use the
             `light` kwarg instead.
 
         The lights contained in this SDF.
     actors : List[Actor]
-        .. depreciated:: SDFormat v1.8
+        .. deprecated:: SDFormat v1.8
             Starting with SDFormat v1.8 only a single actor is supported. Use the
             `actor` kwarg instead.
 
@@ -74,13 +74,13 @@ class Sdf(ElementBase):
     version : str
         The SDFormat version.
     models : List[Model]
-        .. depreciated:: SDFormat v1.8
+        .. deprecated:: SDFormat v1.8
             Use the `Sdf.model` instead.
     lights : List[Light]
-        .. depreciated:: SDFormat v1.8
+        .. deprecated:: SDFormat v1.8
             Use the `Sdf.light` instead.
     actors : List[Actor]
-        .. depreciated:: SDFormat v1.8
+        .. deprecated:: SDFormat v1.8
             Use the `Sdf.actor` instead.
 
     """
@@ -148,11 +148,11 @@ class Sdf(ElementBase):
         except IndexError:
             return None
 
-    # Depreciated properties
+    # deprecated properties
     @property
     def actors(self) -> List[Actor]:
         warnings.warn(
-            "`sdf.actors` is depreciated since SDFormat v1.8. Use `sdf.actor` instead.",
+            "`sdf.actors` is deprecated since SDFormat v1.8. Use `sdf.actor` instead.",
             DeprecationWarning,
         )
         return self._actors
@@ -160,7 +160,7 @@ class Sdf(ElementBase):
     @property
     def models(self) -> List[Model]:
         warnings.warn(
-            "`sdf.models` is depreciated since SDFormat v1.8. Use `sdf.models` instead.",
+            "`sdf.models` is deprecated since SDFormat v1.8. Use `sdf.models` instead.",
             DeprecationWarning,
         )
         return self._models
@@ -168,7 +168,7 @@ class Sdf(ElementBase):
     @property
     def lights(self) -> List[Light]:
         warnings.warn(
-            "`sdf.lights` is depreciated since SDFormat v1.8. Use `sdf.lights` instead.",
+            "`sdf.lights` is deprecated since SDFormat v1.8. Use `sdf.lights` instead.",
             DeprecationWarning,
         )
         return self._lights

--- a/skbot/ignition/sdformat/generic_sdf/sensor.py
+++ b/skbot/ignition/sdformat/generic_sdf/sensor.py
@@ -147,12 +147,12 @@ class Sensor(ElementBase):
     origin : Origin
         The link's origin.
 
-        .. depreciated:: SDFormat v1.2
+        .. deprecated:: SDFormat v1.2
             Use `Sensor.pose` instead.
     frames : List[Frame]
         A list of frames of reference in which poses may be expressed.
 
-        .. depreciated:: SDFormat v1.7
+        .. deprecated:: SDFormat v1.7
             Use :attr:`Model.frame` instead.
         .. versionadded:: SDFormat v1.5
 
@@ -258,7 +258,7 @@ class Sensor(ElementBase):
         elif sdf_version == "1.0":
             self._origin = origin
         else:
-            warnings.warn("`origin` is depreciated. Use `Sensor.pose` instead.")
+            warnings.warn("`origin` is deprecated. Use `Sensor.pose` instead.")
             self._origin = origin
         if sdf_version == "1.0":
             self.pose = self._origin.pose
@@ -311,14 +311,14 @@ class Sensor(ElementBase):
     @property
     def origin(self):
         warnings.warn(
-            "`Sensor.origin` is depreciated since SDFormat v1.2. Use `Sensor.pose` instead."
+            "`Sensor.origin` is deprecated since SDFormat v1.2. Use `Sensor.pose` instead."
         )
         return self._origin
 
     @property
     def frames(self):
         warnings.warn(
-            "`Sensor.frames` is depreciated since SDF v1.7."
+            "`Sensor.frames` is deprecated since SDF v1.7."
             " Use `Model.frames` instead and set `Frame.attached_to` to the name of this link.",
             DeprecationWarning,
         )

--- a/skbot/ignition/sdformat/generic_sdf/world.py
+++ b/skbot/ignition/sdformat/generic_sdf/world.py
@@ -78,7 +78,7 @@ class World(ElementBase):
         Layout of the Ignition Gazebo GUI. (Applications other than Gazebo will
         likely not need this.)
     physics_engine : Physics
-        .. depreciated:: SDFormat v1.6
+        .. deprecated:: SDFormat v1.6
             Use `physics_engines` instead.
 
         Configuration parameters of the dynamics engine.
@@ -102,7 +102,7 @@ class World(ElementBase):
         A list of plugins used to customize the runtime behavior of the
         simulation.
     joints : List[Joint]
-        .. depreciated:: SDFormat v1.7
+        .. deprecated:: SDFormat v1.7
             To attach models to the world, use the canonical_link kwarg
             instead. All other usage of `joints` has no replacement.
 
@@ -165,10 +165,10 @@ class World(ElementBase):
         The current state of this simulation.
 
     physics_engine : Physics
-        .. depreciated:: SDFormat v1.6
+        .. deprecated:: SDFormat v1.6
             Use `physics_engines` instead.
     joints : List[Joint]
-        .. depreciated:: SDFormat v1.7
+        .. deprecated:: SDFormat v1.7
             Use `Model.joints` instead and set `Model.joints.parent` to
             `world`.
 
@@ -228,7 +228,7 @@ class World(ElementBase):
         else:
             if physics_engine is not None:
                 raise ValueError(
-                    "`World.physics_engine` is depreciated. Use `physics_engines` instead."
+                    "`World.physics_engine` is deprecated. Use `physics_engines` instead."
                 )
             self.physics_engines = [] if physics_engines is None else physics_engines
         self.scene = scene
@@ -242,7 +242,7 @@ class World(ElementBase):
             self._joints = [] if joints is None else joints
         elif joints is not None:
             raise ValueError(
-                "`World.joints` is depreciated."
+                "`World.joints` is deprecated."
                 "To connect a model to the world use `Model.canonical_link` instead."
             )
         else:
@@ -282,7 +282,7 @@ class World(ElementBase):
     @property
     def joints(self):
         warnings.warn(
-            "`World.joints` has been depreciated. Use `Model.joints` with"
+            "`World.joints` has been deprecated. Use `Model.joints` with"
             " `Model.joints.parent = 'world'` instead.",
             DeprecationWarning,
         )

--- a/skbot/ignition/sdformat/sdformat.py
+++ b/skbot/ignition/sdformat/sdformat.py
@@ -134,10 +134,10 @@ def loads(
 
     if handler in ["XmlSaxHandler", "LxmlSaxHandler"]:
         warnings.warn(
-            "SAX handlers have been depreciated in xsData >= 21.9;"
+            "SAX handlers have been deprecated in xsData >= 21.9;"
             " falling back to EventHandler. If you need the SAX handler, please open an issue."
             " To make this warning dissapear change `handler` to the corresponding EventHandler.",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
     if handler == "XmlSaxHandler":

--- a/skbot/ignition/sdformat/sdformat.py
+++ b/skbot/ignition/sdformat/sdformat.py
@@ -136,7 +136,8 @@ def loads(
         warnings.warn(
             "SAX handlers have been depreciated in xsData >= 21.9;"
             " falling back to EventHandler. If you need the SAX handler, please open an issue."
-            " To make this warning dissapear change `handler` to the corresponding EventHandler."
+            " To make this warning dissapear change `handler` to the corresponding EventHandler.",
+            DeprecationWarning
         )
 
     if handler == "XmlSaxHandler":

--- a/skbot/ignition/sdformat/transform_factory.py
+++ b/skbot/ignition/sdformat/transform_factory.py
@@ -76,12 +76,12 @@ def to_frame_graph(
     to the child frame is named after the joint (<joint_name>), and the
     (implicit) joint frame attached to the parent is named
     (<joint_name>_parent). The link between the two frames can be retrieved via
-    :func:`skbot.transform.Frame.transform_chain`. For example if there is a
+    :func:`skbot.transform.Frame.links_between`. For example if there is a
     joint named "robot_joint0" its link can be retrieved using::
 
         child_frame = frame_graph.find_frame(".../robot_joint0")
         parent_frame = frame_graph.find_frame(".../robot_joint0_parent")
-        link = child_frame.transform_chain(child_frame)[0]
+        link = child_frame.links_between(child_frame)[0]
     """
 
     root = loads_generic(sdf)

--- a/skbot/inverse_kinematics/__init__.py
+++ b/skbot/inverse_kinematics/__init__.py
@@ -15,7 +15,7 @@ frame coincides with a desired position in the world frame.
 
 While using tool and world frame may be most common - after all it is textbook
 IK -, this module is not limited to these frames. Any two frames that have (at
-least) one valid :func:`transform chain <skbot.transform.Frame.transform_chain>`
+least) one valid :func:`transform chain <skbot.transform.Frame.links_between>`
 between them that depends on the joints can be used. Expanding on the previous
 example, we can specify IK between the camera frame of a static camera and
 panda's tool frame.

--- a/skbot/inverse_kinematics/cyclic_coordinate_descent.py
+++ b/skbot/inverse_kinematics/cyclic_coordinate_descent.py
@@ -80,13 +80,13 @@ def ccd(
     if metric is None:
         metric = lambda x, y: np.linalg.norm(x - y)
 
-    transform_chain = frameA.transform_chain(frameB)
+    links = frameA.links_between(frameB)
 
     def optimizely(x, current_joint):
         current_joint.param = x
 
         current_point = pointA
-        for link in transform_chain:
+        for link in links:
             current_point = link.transform(current_point)
 
         return metric(current_point, pointB)

--- a/skbot/transform/__init__.py
+++ b/skbot/transform/__init__.py
@@ -18,31 +18,28 @@ esoteric transformations like spherical coordinates, too.
 Examples
 --------
 
-Manual construction of a 1D robot arm
-
->>> import skbot.transform as rtf
+>>> import skbot.transform as tf
 >>> import numpy as np
->>> arm_link = rtf.affine.Translation((1, 0))
->>> arm_joint = rtf.affine.Rotation((1, 0), (0, 1))
 
->>> tool_frame = rtf.Frame(2)
->>> ellbow_frame = arm_link(tool_frame)
->>> world_frame = arm_joint(ellbow_frame)
+Forward kinematics on a 1 DoF robot arm in 2D
 
->>> arm_joint.angle = 0
->>> tool_pos = tool_frame.transform((0, 0), to_frame=world_frame)
+>>> # setup of the arm
+>>> link = tf.Translation((1, 0))
+>>> joint = tf.Rotation((1, 0), (0, 1))
+>>> tool_frame = tf.Frame(2)
+>>> joint_frame = link(tool_frame)
+>>> world = joint(joint_frame)
+>>> joint.angle = 0
+>>> # FK of initial position
+>>> tool_pos = tool_frame.transform((0, 0), to_frame=world)
 >>> assert np.allclose(tool_pos, (1, 0))
-
->>> arm_joint.angle = np.pi / 2
->>> tool_pos = tool_frame.transform((0, 0), to_frame=world_frame)
+>>> # Set new joint angle and compute new FK
+>>> joint.angle = np.pi / 2
+>>> tool_pos = tool_frame.transform((0, 0), to_frame=world)
 >>> assert np.allclose(tool_pos, (0, 1))
 
-As with any other repository, you can always find more examples by exploring
-the accompanying unit tests.
-
-
-Basic functions
----------------
+Base Elements
+-------------
 
 .. autosummary::
     :template: transform_class.rst
@@ -50,36 +47,43 @@ Basic functions
 
     Frame
     Link
-    InvertLink
-    CustomLink
-    CompundLink
 
+Available Transformations
+-------------------------
 
-Affine Transformations
-----------------------
+.. rubric:: nD Links
 
 .. autosummary::
     :template: transform_class.rst
     :toctree:
 
+    AffineSpace
     Translation
     Rotation
+    PerspectiveProjection
+
+.. rubric:: 3D Links
+
+.. autosummary::
+    :template: transform_class.rst
+    :toctree:
+
     EulerRotation
     QuaternionRotation
     RotvecRotation
+    FrustumProjection
     RotationalJoint
     PrismaticJoint
 
-
-Projections
------------
+.. rubric:: Other Links
 
 .. autosummary::
     :template: transform_class.rst
     :toctree:
 
-    PerspectiveProjection
-    FrustumProjection
+    CustomLink
+    CompundLink
+    InvertLink
 
 """
 

--- a/skbot/transform/__init__.py
+++ b/skbot/transform/__init__.py
@@ -104,7 +104,7 @@ from .functions import (
     scale,
 )
 
-from .affine import Translation, Rotation, Inverse
+from .affine import Translation, Rotation, Inverse, AffineSpace
 from .projections import PerspectiveProjection
 from .utils3d import (
     FrustumProjection,
@@ -121,22 +121,23 @@ __all__ = [
     "Frame",
     "metrics",  # transform chain metrics
     "Link",
-    # Meta Links
+    # nD Links
+    "AffineSpace",
+    "Rotation",
+    "Translation",
+    "PerspectiveProjection",
+    # 3D Links
+    "EulerRotation",
+    "QuaternionRotation",
+    "RotationalJoint",
+    "PrismaticJoint",
+    "RotvecRotation",
+    "FrustumProjection",
+    # Other Links
     "CustomLink",
     "InvertLink",
     "CompundLink",
-    # Affine Links
-    "RotationalJoint",
-    "PrismaticJoint",
-    "Translation",
-    "Rotation",
-    "EulerRotation",
-    "QuaternionRotation",
-    "RotvecRotation",
     "Inverse",
-    # Projections
-    "PerspectiveProjection",
-    "FrustumProjection",
     # basic transformation functions
     "translate",
     "rotate",

--- a/skbot/transform/affine.py
+++ b/skbot/transform/affine.py
@@ -44,7 +44,7 @@ class AffineLink(Link):
         cartesian_parent = Frame(self.parent_dim)
         cartesian_child = Frame(self.child_dim)
         self(cartesian_parent, cartesian_child)
-        
+
         affine_parent = AffineSpace(self.parent_dim, axis=self._axis)(cartesian_parent)
         affine_child = AffineSpace(self.child_dim, axis=self._axis)(cartesian_child)
 
@@ -57,7 +57,7 @@ class AffineLink(Link):
         cartesian_parent = Frame(self.parent_dim)
         cartesian_child = Frame(self.child_dim)
         self(cartesian_parent, cartesian_child)
-        
+
         affine_parent = AffineSpace(self.parent_dim, axis=self._axis)(cartesian_parent)
         affine_child = AffineSpace(self.child_dim, axis=self._axis)(cartesian_child)
 
@@ -208,7 +208,6 @@ class Translation(AffineLink):
         self._axis = axis
         self._amount = np.asarray(amount)
         self._direction = np.moveaxis(direction, axis, -1)
-
 
     @property
     def direction(self) -> np.ndarray:

--- a/skbot/transform/base.py
+++ b/skbot/transform/base.py
@@ -434,10 +434,10 @@ class Frame:
         metric: Callable[[Tuple["Frame"], Tuple[Link]], float] = DepthFirst,
         max_depth: int = None,
     ) -> List[Link]:
-        """Get a transformation chain into ``to_frame`` (depreciated).
+        """Get a transformation chain into ``to_frame`` (deprecated).
 
-        .. depreciated:: 0.9.0
-            This method is depreciated and will be removed in scikit-bot v1.0.
+        .. deprecated:: 0.9.0
+            This method is deprecated and will be removed in scikit-bot v1.0.
             Use ``Frame.links_between`` instead.
         .. versionadded:: 0.5.0
             This method was added to Frame.
@@ -481,7 +481,7 @@ class Frame:
         """
 
         warnings.warn(
-            "`Frame.transform_chain` is depreciated."
+            "`Frame.transform_chain` is deprecated."
             " Use `Frame.links_between` instead.",
             DeprecationWarning,
         )

--- a/skbot/transform/base.py
+++ b/skbot/transform/base.py
@@ -3,16 +3,17 @@ from typing import List, Tuple, Union, Callable
 import numpy as np
 from dataclasses import dataclass, field
 from queue import PriorityQueue
+import warnings
 
 
 def DepthFirst(frames: Tuple["Frame"], links: Tuple["Link"]) -> float:
-    """Depth-first search metric for Frame.transform_chain"""
+    """Depth-first search metric for Frame.chain_between"""
 
     return -len(links)
 
 
 def BreadthFirst(frames: Tuple["Frame"], links: Tuple["Link"]) -> float:
-    """Beadth-first search metric for Frame.transform_chain"""
+    """Beadth-first search metric for Frame.chain_between"""
     return -1 / len(frames)
 
 
@@ -228,7 +229,7 @@ class Frame:
         """
 
         x_new = np.asarray(x)
-        for link in self.transform_chain(to_frame, ignore_frames=ignore_frames):
+        for link in self.links_between(to_frame, ignore_frames=ignore_frames):
             x_new = link.transform(x_new)
 
         return x_new
@@ -268,7 +269,7 @@ class Frame:
         """
 
         tf_matrix = np.eye(self.ndim + 1)
-        for link in self.transform_chain(to_frame, ignore_frames=ignore_frames):
+        for link in self.links_between(to_frame, ignore_frames=ignore_frames):
             tf_matrix = link.affine_matrix @ tf_matrix
 
         return tf_matrix
@@ -299,7 +300,7 @@ class Frame:
         metric: Callable[[Tuple["Frame"], Tuple[Link]], float],
         max_depth: int,
     ) -> None:
-        """Internal logic for :func:transform_chain.
+        """Internal logic for :func:chain_between.
 
         Appends all children that have not been visited previously to
         the search queue.
@@ -322,26 +323,29 @@ class Frame:
             new_item = QueueItem(priority, new_frames, new_chain)
             queue.put(new_item)
 
-    def transform_chain(
+    def chain_between(
         self,
         to_frame: Union["Frame", str],
         *,
         ignore_frames: List["Frame"] = None,
         metric: Callable[[Tuple["Frame"], Tuple[Link]], float] = DepthFirst,
         max_depth: int = None,
-    ) -> List[Link]:
-        """Get a transformation chain into ``to_frame``.
+    ) -> Tuple[List["Frame"], List[Link]]:
+        """Get the frames and links between this frame and ``to_frame``.
 
-        .. versionadded:: 0.5.0
-            This method was added to Frame.
+        .. versionadded:: 0.9.0
 
         This function searches the frame graph for a chain of transformations
-        from the current frame into ``to_frame`` and returns the sequence of
-        links involved in this transformation. The first element of the returned
-        sequence takes as input the vector expressed in the current frame; each
-        following element takes as input the vector expressed in its
-        predecessor's output frame. The last element outputs the vector
-        expressed in ``to_frame``.
+        from the current frame into ``to_frame`` and returns both, the sequence
+        of frames and the sequence of links involved in this transformation.
+
+        The sequence of frames will have this frame as its first element,
+        and ```to_frame`` as its last element.
+
+        The first element of the returned sequence of links takes as input the
+        vector expressed in the current frame; each following element takes as
+        input the vector expressed in its predecessor's output frame. The last
+        element outputs the vector expressed in ``to_frame``.
 
         Parameters
         ----------
@@ -371,8 +375,14 @@ class Frame:
             If not None, the maximum depth to search, i.e., the maximum length
             of the transform chain.
 
-        """
+        Returns
+        -------
+        frames : List[Frame]
+            A list of frames between this frame and ``to_frame`` (inclusive).
+        links : List[Link]
+            A list of links between this frame and ``to_frame``.
 
+        """
         if max_depth is None:
             max_depth = float("inf")
 
@@ -414,7 +424,195 @@ class Frame:
                 "Did not find a transformation chain to the target frame."
             )
 
-        return sub_chain
+        return list(frames), sub_chain
+
+    def transform_chain(
+        self,
+        to_frame: Union["Frame", str],
+        *,
+        ignore_frames: List["Frame"] = None,
+        metric: Callable[[Tuple["Frame"], Tuple[Link]], float] = DepthFirst,
+        max_depth: int = None,
+    ) -> List[Link]:
+        """Get a transformation chain into ``to_frame`` (depreciated).
+
+        .. depreciated:: 0.9.0
+            This method is depreciated and will be removed in scikit-bot v1.0.
+            Use ``Frame.links_between`` instead.
+        .. versionadded:: 0.5.0
+            This method was added to Frame.
+
+        This function searches the frame graph for a chain of transformations
+        from the current frame into ``to_frame`` and returns the sequence of
+        links involved in this transformation. The first element of the returned
+        sequence takes as input the vector expressed in the current frame; each
+        following element takes as input the vector expressed in its
+        predecessor's output frame. The last element outputs the vector
+        expressed in ``to_frame``.
+
+        Parameters
+        ----------
+        to_frame : Frame, str
+            The frame in which to express vectors. If ``str``, the graph is
+            searched for any node matching that name and the transformation
+            chain to the first node matching the name is returned.
+        ignore_frames : List[Frame]
+            A list of frames to exclude while searching for a transformation
+            chain.
+        metric : Callable[[Tuple[Frame], Tuple[Link]], float]
+            A function to compute the priority of a sub-chain. Sub-chains are
+            searched in order of priority starting with the lowest value. The
+            first chain that matches ``to_frame`` is returned. You can use a
+            custom function that takes a sequence of frames and links involved
+            in the sub-chain as input and returns a float (signature
+            ``custom_fn(frames, links) -> float``), or you can use a pre-build
+            function:
+
+                skbot.transform.metric.DepthFirst
+                    The frame graph is searched depth-first with no
+                    preference among frames (default).
+                skbot.transform.metric.BreadthFirst
+                    The frame graph is searched breadth-first with no
+                    preference among frames.
+        max_depth : int
+            If not None, the maximum depth to search, i.e., the maximum length
+            of the transform chain.
+
+        """
+
+        warnings.warn(
+            "`Frame.transform_chain` is depreciated."
+            " Use `Frame.links_between` instead.",
+            DeprecationWarning,
+        )
+
+        _, links = self.chain_between(
+            to_frame, ignore_frames=ignore_frames, metric=metric, max_depth=max_depth
+        )
+
+        return links
+
+    def links_between(
+        self,
+        to_frame: Union["Frame", str],
+        *,
+        ignore_frames: List["Frame"] = None,
+        metric: Callable[[Tuple["Frame"], Tuple[Link]], float] = DepthFirst,
+        max_depth: int = None,
+    ):
+        """Get the links between this frame and ``to_frame``.
+
+        .. versionadded:: 0.9.0
+
+        This function searches the frame graph for a chain of transformations
+        from the current frame into ``to_frame`` and returns the sequence of
+        links involved in this transformation. The first element of the returned
+        sequence takes as input the vector expressed in the current frame; each
+        following element takes as input the vector expressed in its
+        predecessor's output frame. The last element outputs the vector
+        expressed in ``to_frame``.
+
+        Parameters
+        ----------
+        to_frame : Frame, str
+            The frame in which to express vectors. If ``str``, the graph is
+            searched for any node matching that name and the transformation
+            chain to the first node matching the name is returned.
+        ignore_frames : List[Frame]
+            A list of frames to exclude while searching for a transformation
+            chain.
+        metric : Callable[[Tuple[Frame], Tuple[Link]], float]
+            A function to compute the priority of a sub-chain. Sub-chains are
+            searched in order of priority starting with the lowest value. The
+            first chain that matches ``to_frame`` is returned. You can use a
+            custom function that takes a sequence of frames and links involved
+            in the sub-chain as input and returns a float (signature
+            ``custom_fn(frames, links) -> float``), or you can use a pre-build
+            function:
+
+                skbot.transform.metric.DepthFirst
+                    The frame graph is searched depth-first with no
+                    preference among frames (default).
+                skbot.transform.metric.BreadthFirst
+                    The frame graph is searched breadth-first with no
+                    preference among frames.
+        max_depth : int
+            If not None, the maximum depth to search, i.e., the maximum length
+            of the transform chain.
+
+        """
+
+        _, links = self.chain_between(
+            to_frame, ignore_frames=ignore_frames, metric=metric, max_depth=max_depth
+        )
+
+        return links
+
+    def frames_between(
+        self,
+        to_frame: Union["Frame", str],
+        *,
+        include_self: bool = True,
+        include_to_frame: bool = True,
+        ignore_frames: List["Frame"] = None,
+        metric: Callable[[Tuple["Frame"], Tuple[Link]], float] = DepthFirst,
+        max_depth: int = None,
+    ):
+        """Get the frames between this frame and ``to_frame``.
+
+        .. versionadded:: 0.9.0
+
+        This function searches the frame graph for a chain of transformations
+        from the current frame into ``to_frame`` and returns the sequence of
+        frames between this frame and ``to_frame``.
+
+        Parameters
+        ----------
+        include_self : bool
+            If ``True`` (default) this frame will be added as the first
+            element of the returned sequence.
+        include_to_frame : bool
+            If ``True`` (default) ``to_frame`` will be added as the last
+            element of the returned sequence.
+        to_frame : Frame, str
+            The frame in which to express vectors. If ``str``, the graph is
+            searched for any node matching that name and the transformation
+            chain to the first node matching the name is returned.
+        ignore_frames : List[Frame]
+            A list of frames to exclude while searching for a transformation
+            chain.
+        metric : Callable[[Tuple[Frame], Tuple[Link]], float]
+            A function to compute the priority of a sub-chain. Sub-chains are
+            searched in order of priority starting with the lowest value. The
+            first chain that matches ``to_frame`` is returned. You can use a
+            custom function that takes a sequence of frames and links involved
+            in the sub-chain as input and returns a float (signature
+            ``custom_fn(frames, links) -> float``), or you can use a pre-build
+            function:
+
+                skbot.transform.metric.DepthFirst
+                    The frame graph is searched depth-first with no
+                    preference among frames (default).
+                skbot.transform.metric.BreadthFirst
+                    The frame graph is searched breadth-first with no
+                    preference among frames.
+        max_depth : int
+            If not None, the maximum depth to search, i.e., the maximum length
+            of the transform chain.
+
+        """
+
+        frames, _ = self.chain_between(
+            to_frame, ignore_frames=ignore_frames, metric=metric, max_depth=max_depth
+        )
+
+        if not include_self:
+            frames.pop(0)
+
+        if not include_to_frame:
+            frames.pop(-1)
+
+        return frames
 
     def find_frame(self, path: str, *, ignore_frames: List["Frame"] = None) -> "Frame":
         """Find a frame matching a given path.

--- a/skbot/transform/functions.py
+++ b/skbot/transform/functions.py
@@ -174,7 +174,7 @@ def shear(
     return vector + tmp1 * direction
 
 
-def as_affine_matrix(from_frame:Frame, to_frame:Frame, *, axis:int=-1):
+def as_affine_matrix(from_frame: Frame, to_frame: Frame, *, axis: int = -1):
     """Transformation Matrix between two frames at a given point.
 
     Given two frames ``from_frame`` and ``to_frame`` that represent affine space
@@ -196,13 +196,13 @@ def as_affine_matrix(from_frame:Frame, to_frame:Frame, *, axis:int=-1):
     matrix : np.ndarray
         The matrix representation of the transformation. It will have the shape
         ``(batch_shape, to_frame.ndim, from_frame.ndim)``.
-    
+
     Notes
     -----
     The matrix representation will only be accurate if the transformation chain
     between the two given frames is linear.
 
-    The 
+    The
 
     """
 
@@ -213,7 +213,7 @@ def as_affine_matrix(from_frame:Frame, to_frame:Frame, *, axis:int=-1):
     basis_set[:, -1] = 1
 
     mapped_basis = from_frame.transform(basis_set, to_frame).T
-    
+
     # normalize affine matrix
     scaling = mapped_basis[-1, :]
     mapped_basis /= scaling[None, :]

--- a/skbot/transform/functions.py
+++ b/skbot/transform/functions.py
@@ -1,7 +1,7 @@
 import numpy as np
-from math import sin, cos
 from numpy.typing import ArrayLike
 
+from .base import Frame
 from ._utils import vector_project
 
 
@@ -172,3 +172,51 @@ def shear(
     tmp1 = np.sum(vector * amount, axis=axis)
 
     return vector + tmp1 * direction
+
+
+def as_affine_matrix(from_frame:Frame, to_frame:Frame, *, axis:int=-1):
+    """Transformation Matrix between two frames at a given point.
+
+    Given two frames ``from_frame`` and ``to_frame`` that represent affine space
+    and are connected by a sequence of linear transformations, compute a matrix
+    representation of the transformation.
+
+    Parameters
+    ----------
+    from_frame : tf.Frame
+        The parent frame.
+    to_frame : tf.Frame
+        The child frame.
+    axis : int
+        The axis along which computation takes place. All other axes are considered
+        batch dimensions.
+
+    Returns
+    -------
+    matrix : np.ndarray
+        The matrix representation of the transformation. It will have the shape
+        ``(batch_shape, to_frame.ndim, from_frame.ndim)``.
+    
+    Notes
+    -----
+    The matrix representation will only be accurate if the transformation chain
+    between the two given frames is linear.
+
+    The 
+
+    """
+
+    if axis != -1:
+        raise NotImplementedError("Axis is not implemented yet.")
+
+    basis_set = np.eye(from_frame.ndim)
+    basis_set[:, -1] = 1
+
+    mapped_basis = from_frame.transform(basis_set, to_frame).T
+    
+    # normalize affine matrix
+    scaling = mapped_basis[-1, :]
+    mapped_basis /= scaling[None, :]
+    mapped_basis[..., :-1] -= mapped_basis[..., -1][..., None]
+
+    return mapped_basis

--- a/skbot/transform/joints.py
+++ b/skbot/transform/joints.py
@@ -5,6 +5,32 @@ from .affine import Translation
 
 
 class RotationalJoint(RotvecRotation):
+    """Rotation with constraints in 3D.
+
+    Parameters
+    ----------
+    rotvec : ArrayLike
+        The vector around which points are rotated.
+    angle : ArrayLike
+        The magnitude of the rotation. If None, the length of ``vector`` will be
+        used.
+    degrees : bool
+        If True, angle is assumed to be in degrees. Default is False.
+    axis : int
+        The axis along which to to compute. Default: -1.
+    upper_limit : ArrayLike
+        The maximum joint angle. Default: 2pi.
+    lower_limit : ArrayLike
+        The minimum joint angle. Default: 0.
+
+    Notes
+    -----
+    Batch dimensions of ``rotvec`` and ``angle`` must be broadcastable.
+
+    Setting ``RotationalJoint.angle`` will check if the joint angle limits are
+    respected; however, setting ``RotationalJoint.param`` will not.
+    
+    """
     def __init__(
         self,
         rotvec: ArrayLike,
@@ -21,6 +47,7 @@ class RotationalJoint(RotvecRotation):
 
     @property
     def param(self) -> float:
+        """Magnitude of the rotation (in radians)."""
         return self._angle
 
     @param.setter
@@ -43,6 +70,28 @@ class RotationalJoint(RotvecRotation):
 
 
 class PrismaticJoint(Translation):
+    """Translation with constraints in 3D.
+
+    Parameters
+    ----------
+    direction : ArrayLike
+        A vector describing the translation.
+    amount : ArrayLike
+        A scalar indicating by how much to scale ``direction``. Default is 1.
+    axis : int
+        The axis along which computation takes place. All other axes are considered
+        batch dimensions.
+    upper_limit : ArrayLike
+        The maximum value of amount. Default: 1.
+    lower_limit : ArrayLike
+        The minimum value of amount. Default: 0.
+
+    Notes
+    -----
+    Setting ``PrismaticJoint.amount`` will enforce joint limits; however,
+    setting ``PrismaticJoint.param`` will not.
+
+    """
     def __init__(
         self,
         direction: ArrayLike,

--- a/skbot/transform/joints.py
+++ b/skbot/transform/joints.py
@@ -29,8 +29,9 @@ class RotationalJoint(RotvecRotation):
 
     Setting ``RotationalJoint.angle`` will check if the joint angle limits are
     respected; however, setting ``RotationalJoint.param`` will not.
-    
+
     """
+
     def __init__(
         self,
         rotvec: ArrayLike,
@@ -89,6 +90,7 @@ class PrismaticJoint(Translation):
     setting ``PrismaticJoint.param`` will not.
 
     """
+
     def __init__(
         self,
         direction: ArrayLike,

--- a/skbot/transform/joints.py
+++ b/skbot/transform/joints.py
@@ -56,9 +56,6 @@ class RotationalJoint(RotvecRotation):
 
         self._v = np.cos(value / 2) * self._u - np.sin(value / 2) * self._u_ortho
 
-        self._update_transformation_matrix(self._u.shape)
-        self._update_inverse_transformation_matrix(self._u.shape)
-
     @RotvecRotation.angle.setter
     def angle(self, angle: ArrayLike) -> None:
         angle = np.asarray(angle)
@@ -113,9 +110,6 @@ class PrismaticJoint(Translation):
     @param.setter
     def param(self, value: ArrayLike) -> None:
         self._amount = np.asarray(value)
-
-        self._update_transformation_matrix(self._direction.shape)
-        self._update_inverse_transformation_matrix(self._direction.shape)
 
     @Translation.amount.setter
     def amount(self, amount: ArrayLike) -> None:

--- a/tests/ignition/test_sdformat.py
+++ b/tests/ignition/test_sdformat.py
@@ -51,8 +51,9 @@ def test_custom_constructor(valid_sdf_string):
 def test_sax_handlers():
     sdf_file = Path(__file__).parent / "sdf" / "sdformat" / "empty.sdf"
 
-    ign.sdformat.loads(sdf_file.read_text(), handler="XmlSaxHandler")
-    ign.sdformat.loads(sdf_file.read_text(), handler="LxmlSaxHandler")
+    with pytest.deprecated_call():
+        ign.sdformat.loads(sdf_file.read_text(), handler="XmlSaxHandler")
+        ign.sdformat.loads(sdf_file.read_text(), handler="LxmlSaxHandler")
 
 
 def test_idempotence(valid_sdf_string):

--- a/tests/ignition/test_transform_factory.py
+++ b/tests/ignition/test_transform_factory.py
@@ -98,7 +98,7 @@ def test_static_graph(verifiable_sdf_string):
             # each frame should be reachable from the root frame
             for name, frame in static_frames.items():
                 try:
-                    tf_chain = root.transform_chain(frame)
+                    tf_chain = root.links_between(frame)
                 except RuntimeError:
                     raise AssertionError(
                         "A Frame in the static graph is unreachable."
@@ -204,10 +204,10 @@ def test_must_be_base_link():
     world_frame = world_sdf.to_dynamic_graph(frames)
 
     for name in ["A", "B", "C", "D"]:
-        chain = world_frame.transform_chain(name)
+        chain = world_frame.links_between(name)
         assert len(chain) == 1
 
-        chain = world_frame.find_frame(f"world/{name}").transform_chain(world_frame)
+        chain = world_frame.find_frame(f"world/{name}").links_between(world_frame)
         assert len(chain) == 1
 
 

--- a/tests/inverse_kinematics/conftest.py
+++ b/tests/inverse_kinematics/conftest.py
@@ -18,7 +18,7 @@ def panda():
     tool_frame = base_frame.find_frame(".../panda_link8")
 
     joints = list()
-    for link in tool_frame.transform_chain(base_frame):
+    for link in tool_frame.links_between(base_frame):
         if isinstance(link, (tf.RotationalJoint, tf.PrismaticJoint)):
             joints.append(link)
 
@@ -33,7 +33,7 @@ def double_pendulum():
     tool_frame = base_frame.find_frame(".../lower_link")
 
     joints = list()
-    for link in tool_frame.transform_chain(base_frame):
+    for link in tool_frame.links_between(base_frame):
         if isinstance(link, (tf.RotationalJoint, tf.PrismaticJoint)):
             joints.append(link)
 

--- a/tests/transform/test_affine.py
+++ b/tests/transform/test_affine.py
@@ -111,16 +111,8 @@ def test_affine():
     cartesian = tf.Frame(3)
     affine = tf.AffineSpace(3)(cartesian)
 
-    input = np.array([
-        [1, 0, 0],
-        [1, 1, 0],
-        [1, 1, 1]
-    ])
-    expected = np.array([
-        [1, 0, 0, 1],
-        [1, 1, 0, 1],
-        [1, 1, 1, 1]
-    ])
+    input = np.array([[1, 0, 0], [1, 1, 0], [1, 1, 1]])
+    expected = np.array([[1, 0, 0, 1], [1, 1, 0, 1], [1, 1, 1, 1]])
 
     as_affine = cartesian.transform(input, affine)
     assert np.allclose(as_affine, expected)
@@ -128,12 +120,14 @@ def test_affine():
     as_cartesian = affine.transform(as_affine, cartesian)
     assert np.allclose(as_cartesian, input)
 
-    input = np.array([
-        [1, 1, 1, 1],
-        [0.5, 0.5, 0.5, 0.5],
-        [3, 3, 3, 3],
-        [0.1, 0.1, 0.1, 0.1],
-    ])
-    expected = np.ones((4,3))
+    input = np.array(
+        [
+            [1, 1, 1, 1],
+            [0.5, 0.5, 0.5, 0.5],
+            [3, 3, 3, 3],
+            [0.1, 0.1, 0.1, 0.1],
+        ]
+    )
+    expected = np.ones((4, 3))
     result = affine.transform(input, cartesian)
     assert np.allclose(result, expected)

--- a/tests/transform/test_affine.py
+++ b/tests/transform/test_affine.py
@@ -105,3 +105,35 @@ def test_translation_dims():
 
     assert link.parent_dim == 3
     assert link.child_dim == 3
+
+
+def test_affine():
+    cartesian = tf.Frame(3)
+    affine = tf.AffineSpace(3)(cartesian)
+
+    input = np.array([
+        [1, 0, 0],
+        [1, 1, 0],
+        [1, 1, 1]
+    ])
+    expected = np.array([
+        [1, 0, 0, 1],
+        [1, 1, 0, 1],
+        [1, 1, 1, 1]
+    ])
+
+    as_affine = cartesian.transform(input, affine)
+    assert np.allclose(as_affine, expected)
+
+    as_cartesian = affine.transform(as_affine, cartesian)
+    assert np.allclose(as_cartesian, input)
+
+    input = np.array([
+        [1, 1, 1, 1],
+        [0.5, 0.5, 0.5, 0.5],
+        [3, 3, 3, 3],
+        [0.1, 0.1, 0.1, 0.1],
+    ])
+    expected = np.ones((4,3))
+    result = affine.transform(input, cartesian)
+    assert np.allclose(result, expected)

--- a/tests/transform/test_base.py
+++ b/tests/transform/test_base.py
@@ -33,9 +33,7 @@ def test_chain_resolution_bfs(simple_graph: List[tf.Frame]):
     assert len(links) == 3
 
     # depends on which link is expanded first
-    links = simple_graph[0].links_between(
-        simple_graph[7], metric=tf.metrics.DepthFirst
-    )
+    links = simple_graph[0].links_between(simple_graph[7], metric=tf.metrics.DepthFirst)
     assert len(links) == 3 or len(links) == 5
 
 

--- a/tests/transform/test_base.py
+++ b/tests/transform/test_base.py
@@ -86,7 +86,7 @@ def test_compound_frame(vec_child, vec_parent):
     assert np.allclose(out, vec_child)
 
 
-def test_named_transform_chain():
+def test_named_links_between():
     link = tf.Translation((1, 0))
 
     a = tf.Frame(2, name="foo")
@@ -95,6 +95,20 @@ def test_named_transform_chain():
     z = link(y)
 
     elements = z.links_between("foo")
+
+    assert len(elements) == 3
+
+
+def test_named_links_between():
+    link = tf.Translation((1, 0))
+
+    a = tf.Frame(2, name="foo")
+    x = link(a)
+    y = link(x)
+    z = link(y)
+
+    with pytest.deprecated_call():
+        elements = z.transform_chain("foo")
 
     assert len(elements) == 3
 
@@ -118,3 +132,24 @@ def test_inverse_inverse():
     expected = link.transform(point)
 
     assert np.allclose(result, expected)
+
+
+def test_frames_between():
+    link = tf.Translation((1, 0))
+
+    a = tf.Frame(2, name="foo")
+    x = link(a)
+    y = link(x)
+    z = link(y)
+
+    elements = z.frames_between("foo")
+    assert len(elements) == 4
+    assert elements[0] == z
+    assert elements[1] == y
+    assert elements[2] == x
+    assert elements[3] == a
+
+    elements = z.frames_between("foo", include_self=False, include_to_frame=False)
+    assert len(elements) == 2
+    assert elements[0] == y
+    assert elements[1] == x

--- a/tests/transform/test_base.py
+++ b/tests/transform/test_base.py
@@ -27,13 +27,13 @@ def test_chain_resolution_dfs(simple_graph: List[tf.Frame]):
 
 
 def test_chain_resolution_bfs(simple_graph: List[tf.Frame]):
-    links = simple_graph[0].transform_chain(
+    links = simple_graph[0].links_between(
         simple_graph[7], metric=tf.metrics.BreadthFirst
     )
     assert len(links) == 3
 
     # depends on which link is expanded first
-    links = simple_graph[0].transform_chain(
+    links = simple_graph[0].links_between(
         simple_graph[7], metric=tf.metrics.DepthFirst
     )
     assert len(links) == 3 or len(links) == 5
@@ -41,7 +41,7 @@ def test_chain_resolution_bfs(simple_graph: List[tf.Frame]):
 
 def test_transform_chain_max_depth(simple_graph: List[tf.Frame]):
     with pytest.raises(RuntimeError):
-        simple_graph[0].transform_chain(simple_graph[7], max_depth=2)
+        simple_graph[0].links_between(simple_graph[7], max_depth=2)
 
 
 def test_find_frame(simple_graph):
@@ -94,7 +94,7 @@ def test_named_transform_chain():
     y = link(x)
     z = link(y)
 
-    elements = z.transform_chain("foo")
+    elements = z.links_between("foo")
 
     assert len(elements) == 3
 


### PR DESCRIPTION
- Renamed Frame.transform_chain to Frame.links_between.
- Added Frame.chain_between
- Added Frame.chain_between
- Added AffineSpace (transformation to and from affine space)
- Refactored various links to not trigger an update of `affine_matrix` on parameter update, but to instead update lazily.
