### PR TITLE
FEAT: L-BFGS-B based inverse kinematics

### DIFF
--- a/skbot/inverse_kinematics/__init__.py
+++ b/skbot/inverse_kinematics/__init__.py
@@ -1,38 +1,42 @@
 """
 Inverse Kinematics (IK) Algorithms.
 
-The algorithms in this module assume that the environment is expressed as a
-frame graph (see :mod:`skbot.transform`). Once this is done, the problem of
-inverse kinematics can be neatly expressed as finding parameters for a set of
-:class:`Links <skbot.transform.Link>` such that a point (or set of points,
-depending on the algorithm) that has a certain representation in one frame has a
-certain representation in another frame.
+.. currentmodule:: skbot.inverse_kinematics
 
-For example, for a robot like panda we know the tool position in the tool frame
-(often 0), and we wish to change the joint angles (joints are
-:class:`Links <skbot.transform.Link>`) such that the given position in the tool
-frame coincides with a desired position in the world frame.
+The algorithms in this module find values for a set of joints (a glorified list
+of :class:`tf.Links <skbot.transform.Link>`) such that the score of one or more
+:class:`Targets <Target>` is minimal.
 
-While using tool and world frame may be most common - after all it is textbook
-IK -, this module is not limited to these frames. Any two frames that have (at
-least) one valid :func:`transform chain <skbot.transform.Frame.links_between>`
-between them that depends on the joints can be used. Expanding on the previous
-example, we can specify IK between the camera frame of a static camera and
-panda's tool frame.
+:class:`Targets <Target>` are specified between two :class`tf.Frames
+<skbot.transform.Frame>` that are connected by a sequence of :class:`tf.Links
+<skbot.transform.Link>` (the kinematic chain). For example, the
+:class:`PositionTarget` can be used to specify that a static position in a
+robot's tool frame should have a certain dynamic position when transformed into
+the world frame. The available IK algorithms will then attempt to find values
+for the ``joints`` between these two frames such that the value of the
+transformed static position and the value of dynamic position are identical.
 
+Targets
+-------
 
+.. autosummary::
+    :toctree:
+    PositionTarget
+    RotationTarget
 
-Functions
----------
+IK Algorithms
+-------------
 
 .. autosummary::
     :toctree:
 
     skbot.inverse_kinematics.ccd
+    skbot.inverse_kinematics.gd
 
 """
 
 from .targets import Target, PositionTarget, RotationTarget
 from .cyclic_coordinate_descent import ccd
+from .gradient_descent import gd
 
-__all__ = ["ccd", "Target", "PositionTarget", "RotationTarget"]
+__all__ = ["ccd", "gd", "Target", "PositionTarget", "RotationTarget"]

--- a/skbot/inverse_kinematics/__init__.py
+++ b/skbot/inverse_kinematics/__init__.py
@@ -5,22 +5,23 @@ Inverse Kinematics (IK) Algorithms.
 
 The algorithms in this module find values for a set of joints (a glorified list
 of :class:`tf.Links <skbot.transform.Link>`) such that the score of one or more
-:class:`Targets <Target>` is minimal.
+Targets is below a given threshold.
 
-:class:`Targets <Target>` are specified between two :class`tf.Frames
-<skbot.transform.Frame>` that are connected by a sequence of :class:`tf.Links
-<skbot.transform.Link>` (the kinematic chain). For example, the
-:class:`PositionTarget` can be used to specify that a static position in a
-robot's tool frame should have a certain dynamic position when transformed into
-the world frame. The available IK algorithms will then attempt to find values
-for the ``joints`` between these two frames such that the value of the
-transformed static position and the value of dynamic position are identical.
+Targets are specified between two :class:`tf.Frames <skbot.transform.Frame>`
+that are connected by a sequence of :class:`tf.Links <skbot.transform.Link>`
+(the kinematic chain). For example, the :class:`PositionTarget` can be used to
+specify that a position in a robot's tool frame should have a certain position
+when transformed into the world frame. The available IK algorithms will then
+attempt to find values for the chosen joints - which are assumed to be between
+these two frames - such that the value of the transformed tool position and the
+value of the world position is closer than some threshold.
 
 Targets
 -------
 
 .. autosummary::
     :toctree:
+
     PositionTarget
     RotationTarget
 

--- a/skbot/inverse_kinematics/__init__.py
+++ b/skbot/inverse_kinematics/__init__.py
@@ -32,6 +32,7 @@ Functions
 
 """
 
+from .targets import Target, PositionTarget, RotationTarget
 from .cyclic_coordinate_descent import ccd
 
-__all__ = ["ccd"]
+__all__ = ["ccd", "Target", "PositionTarget", "RotationTarget"]

--- a/skbot/inverse_kinematics/cyclic_coordinate_descent.py
+++ b/skbot/inverse_kinematics/cyclic_coordinate_descent.py
@@ -10,23 +10,27 @@ joint = Union[tf.PrismaticJoint, tf.RotationalJoint]
 
 
 def ccd(
-    pointA: ArrayLike,
-    pointB: ArrayLike,
-    frameA: tf.Frame,
-    frameB: tf.Frame,
+    pointA: Union[ArrayLike, List[ArrayLike]],
+    pointB: Union[ArrayLike, List[ArrayLike]],
+    frameA: Union[tf.Frame, List[tf.Frame]],
+    frameB: Union[tf.Frame, List[tf.Frame]],
     cycle_links: List[joint],
     *,
     metric: Callable[[np.ndarray, np.ndarray], float] = None,
     tol: float = 1e-3,
     maxiter: int = 500,
     line_search_maxiter: int = 500,
+    weights: List[float] = None,
 ) -> List[np.ndarray]:
     """Cyclic Coordinate Descent.
 
     .. note::
         This function will modify the passed-in frame graph as a side effect.
 
+    .. versionadded:: 0.8.1
+        CCD can now jointly optimize for multiple targets.
     .. versionadded:: 0.7.0
+        CCD was added to scikit-bot.
 
     This function adjusts the parameters of the links in ``cycle_links`` such that a
     point that has ``pointA`` as its representation in ``frameA`` has ``pointB``
@@ -39,26 +43,40 @@ def ccd(
     Parameters
     ----------
     pointA : ArrayLike
-        The representation of the point in frameA.
+        A list of points. The i-th pointA is represented in the i-th frame of
+        frameA. If only one point is given, the list can be omitted and the point
+        can be directly used as input.
     pointB : ArrayLike
-        The desired representation of the point in frameB.
+        The desired positions of each point given in pointA. The i-th pointB is
+        represented in the i-th frame of frameB. If only one point is given, the
+        list can be omitted and the point can be directly used as input.
     frameA : tf.Frame
-        The frame in which pointA is represented.
+        The frame in which the points in pointA are represented. The i-th
+        element corresponds to the i-th pointA. If only one point is given, the
+        list can be omitted and the frame can be directly used as input.
     frameB : tf.Frame
-        The frame in which pointB is represented.
+        The frame in which the points in pointB are represented. The i-th
+        element corresponds to the i-th pointB. If only one point is given, the
+        list can be omitted and the frame can be directly used as input.
     cycle_links: List[joint]
         A list of 1DoF joints which should be adjusted to make pointA and pointB
-        valid representations of the same point.
+        valid representations of the same points.
     metric : Callable
-        A function that takes two points (expressed in frameB) and computs the
-        distance between them. Its signature is ``metric(transformed_point,
-        pointB) -> distance``. If None, the euclidian distance will be used.
+        A function that takes two points (expressed in the corresponding frameB)
+        and that computs the distance between them. Its signature is
+        ``metric(transformed_point, pointB) -> distance``. If None, the
+        euclidian distance will be used.
     tol : float
-        Absolute tolerance for termination.
+        Absolute tolerance for termination. Defaults to 0.001, which corresponds
+        to 1 mm if the coordinate systems use meters as unit.
     maxiter : int
         The maximum number of cycles to perform.
     line_search_maxiter : int
-        The maximum number of iterations to use when optimizing a single joint.
+        The maximum number of iterations to use when optimizing a single joint
+        during a cycle.
+    weights : List[float]
+        The relative weight to give to each quartet ``(pointA[i], pointB[i],
+        frameA[i], frameB[i])``. If None, each element will have equal weight.
 
     Returns
     -------
@@ -67,7 +85,19 @@ def ccd(
 
     Notes
     -----
+    The number of elements given to ``pointA``, ``pointB``, ``frameA``, and
+    ``frameB`` must match.
+
     Joint limits (min/max) are enforced as hard constraints.
+
+    To specify both a position and orientation you can pass a list of two
+    points. The second point expresses the orientation and *has unit
+    length*. For example, to move a robot's tool frame to the target position
+    ``(a, b, c)`` in the world_frame and align the frame's x-axis with the
+    world's y-axis you could call::
+
+        ik.ccd([(0, 0, 0), (1, 0, 0)], [(a, b, c), (0, 1, 0)],
+               [tool_frame, tool_frame], [world_frame, world_frame])
 
     The current implementation is a naive python implementation and not very
     optimized. PRs improving performance are welcome :)
@@ -75,24 +105,44 @@ def ccd(
     """
 
     joints = cycle(cycle_links)
-    joint_values = [0] * len(cycle_links)
+    joint_values = [l.param for l in cycle_links]
 
     if metric is None:
         metric = lambda x, y: np.linalg.norm(x - y)
 
-    links = frameA.links_between(frameB)
+    if not isinstance(frameA, list):
+        frameA = [frameA]
+        frameB = [frameB]
+        pointA = [pointA]
+        pointB = [pointB]
 
-    def optimizely(x, current_joint):
+    pointA = [x for x in map(np.asarray, pointA)]
+    pointB = [x for x in map(np.asarray, pointB)]
+
+    targets = [
+        (x[0], x[1], x[2].links_between(x[3]))
+        for x in zip(pointA, pointB, frameA, frameB)
+    ]
+
+    if weights is None:
+        weights = [1 / len(targets)] * len(targets)
+
+    def score() -> float:
+        scores = np.empty((len(targets),), dtype=np.float_)
+        for idx in range(len(targets)):
+            current_point, target_point, chain = targets[idx]
+            for link in chain:
+                current_point = link.transform(current_point)
+            scores[idx] = metric(current_point, target_point)
+
+        return np.sum(weights * scores)
+
+    def optimizely(x: float, current_joint: joint) -> float:
         current_joint.param = x
-
-        current_point = pointA
-        for link in links:
-            current_point = link.transform(current_point)
-
-        return metric(current_point, pointB)
+        return score()
 
     for _ in range(maxiter * len(cycle_links)):
-        distance = metric(frameA.transform(pointA, frameB), pointB)
+        distance = score()
 
         if distance <= tol:
             break

--- a/skbot/inverse_kinematics/cyclic_coordinate_descent.py
+++ b/skbot/inverse_kinematics/cyclic_coordinate_descent.py
@@ -239,9 +239,9 @@ def ccd(
             DeprecationWarning,
         )
 
-        target = PositionTarget(targets, joints, args[2], args[3])
+        target = PositionTarget(targets, joints, args[0], args[1])
         targets = [target]
-        joints = args[4]
+        joints = args[2]
 
     elif frameA is not None:
         warnings.warn(

--- a/skbot/inverse_kinematics/cyclic_coordinate_descent.py
+++ b/skbot/inverse_kinematics/cyclic_coordinate_descent.py
@@ -85,10 +85,6 @@ def analytic_rotation(
         if np.linalg.norm(target_projected) < eps:
             return
 
-        # skip adjustment if the current position is in the joints null space
-        if np.linalg.norm(current_projected) < eps:
-            return
-
         target_angle = angle_between(target_projected, basis1)
         if angle_between(target_projected, basis2) > np.pi / 2:
             target_angle = -target_angle

--- a/skbot/inverse_kinematics/gradient_descent.py
+++ b/skbot/inverse_kinematics/gradient_descent.py
@@ -1,18 +1,15 @@
 from .. import transform as tf
-from .targets import Target, PositionTarget, RotationTarget
+from .targets import Target
 from typing import List
-from numpy.typing import ArrayLike
 import numpy as np
 from .types import IKJoint
 from scipy.optimize import minimize, OptimizeResult, Bounds
-import warnings
 
 
 def gd(
     targets: List[Target],
     joints: List[IKJoint],
     *,
-    jacobian=None,
     atol: float = 1e-3,
     rtol: float = 1e-6,
     maxiter: int = 500,
@@ -41,8 +38,9 @@ def gd(
         estimate.
     atol : float
         Absolute tolerance above which the IK is considered to have failed.
+        Default: ``1e-3``.
     rtol : float
-        Relative tolerance for termination. Defaults to 1e-6.
+        Relative tolerance for termination. Defaults to ``1e-6``.
     maxiter : int
         The maximum number of iterations.
 
@@ -86,14 +84,16 @@ def gd(
         joint_values,
         bounds=bounds,
         method="L-BFGS-B",
-        options={"maxiter": maxiter, "ftol":rtol},
+        options={"maxiter": maxiter, "ftol": rtol},
     )
 
     if not result.success:
         raise RuntimeError(f"IK failed. Reason: {result.message}")
 
     if result.fun > atol:
-        raise RuntimeError(f"IK failed. Reason: Loss in the local minimum is greater than `atol`.")
+        raise RuntimeError(
+            f"IK failed. Reason: Loss in the local minimum is greater than `atol`."
+        )
 
     for joint, value in zip(joints, result.x):
         joint.param = value

--- a/skbot/inverse_kinematics/gradient_descent.py
+++ b/skbot/inverse_kinematics/gradient_descent.py
@@ -88,11 +88,11 @@ def gd(
             options={"maxiter": maxiter, "ftol": rtol},
         )
 
-        if not result.success:
-            raise RuntimeError(f"IK failed. Reason: {result.message}")
-
         scores = np.array([x.score() for x in targets])
         if np.any(scores > atols):
+            if not result.success:
+                raise RuntimeError(f"IK failed. Reason: {result.message}")
+
             raise RuntimeError(
                 f"IK failed. Reason: Local minimum doesn't reach one or more targets."
             )

--- a/skbot/inverse_kinematics/gradient_descent.py
+++ b/skbot/inverse_kinematics/gradient_descent.py
@@ -90,7 +90,9 @@ def gd(
         )
 
         if not result.success:
-            warnings.warn(f"L-BFGS-B terminated abnormally with message `{result.message}`.")
+            warnings.warn(
+                f"L-BFGS-B terminated abnormally with message `{result.message}`."
+            )
 
         scores = np.array([x.score() for x in targets])
         if np.any(scores > atols):

--- a/skbot/inverse_kinematics/gradient_descent.py
+++ b/skbot/inverse_kinematics/gradient_descent.py
@@ -1,0 +1,101 @@
+from .. import transform as tf
+from .targets import Target, PositionTarget, RotationTarget
+from typing import List
+from numpy.typing import ArrayLike
+import numpy as np
+from .types import IKJoint
+from scipy.optimize import minimize, OptimizeResult, Bounds
+import warnings
+
+
+def gd(
+    targets: List[Target],
+    joints: List[IKJoint],
+    *,
+    jacobian=None,
+    atol: float = 1e-3,
+    rtol: float = 1e-6,
+    maxiter: int = 500,
+):
+    """L-BFGS-B based Gradient Descent
+
+    .. note::
+        This function will modify the links given via ``joints`` as a side effect.
+
+    Use the gradient descent method specified by ``method`` to find values for
+    ``joints`` that minimize ``targets``. The implementation relies on
+    ``scipy.optimize``, and all methods that scipy supports are available.
+
+    Parameters
+    ----------
+    targets : List[Target]
+        A list of quality measures that a successful pose minimizes.
+    joints : List[joint]
+        A list of 1DoF joints which should be adjusted to minimize targets.
+    jacobian : Callable
+        A callable with signature `jacobian(np.ndarray) -> ArrayLike` that
+        computes the robot's jacobi matrix at the respective position. The input
+        will be an array of shape (len(joints),) and it should return an
+        ArrayLike with shape (len(joints), len(joints)). If ``None`` (default)
+        the jacobian will be approximated using a 2-point finite difference
+        estimate.
+    atol : float
+        Absolute tolerance above which the IK is considered to have failed.
+    rtol : float
+        Relative tolerance for termination. Defaults to 1e-6.
+    maxiter : int
+        The maximum number of iterations.
+
+    Returns
+    -------
+    joint_values : List[float]
+        The final parameters of each joint.
+
+    Notes
+    -----
+    A common cause of IK faulure due to the chosen initial condition
+    is too far away from the desired target position. One indicator for this
+    is that :fun:`gd` converges based on ``rtol``, but the result doesn't fall
+    under ``atol``.
+
+    """
+
+    joint_values = np.array([l.param for l in joints])
+
+    for target in targets:
+        target._chain = tf.simplify_links(target._chain, keep_links=joints)
+
+    bounds = Bounds(
+        [x.lower_limit for x in joints],
+        [x.upper_limit for x in joints],
+        keep_feasible=True,
+    )
+
+    # make params views into joint_values
+    for idx in range(len(joints)):
+        joints[idx].param = joint_values[idx : idx + 1]
+
+    def objective_function(joint_config: np.ndarray) -> float:
+        for joint, value in zip(joints, joint_config):
+            joint.param = value
+        scores = np.array([x.score() for x in targets])
+        return np.sum(scores)
+
+    result: OptimizeResult = minimize(
+        objective_function,
+        joint_values,
+        bounds=bounds,
+        method="L-BFGS-B",
+        options={"maxiter": maxiter, "ftol":rtol},
+    )
+
+    if not result.success:
+        raise RuntimeError(f"IK failed. Reason: {result.message}")
+
+    if result.fun > atol:
+        raise RuntimeError(f"IK failed. Reason: Loss in the local minimum is greater than `atol`.")
+
+    for joint, value in zip(joints, result.x):
+        joint.param = value
+
+    return joint_values

--- a/skbot/inverse_kinematics/gradient_descent.py
+++ b/skbot/inverse_kinematics/gradient_descent.py
@@ -4,6 +4,7 @@ from typing import List
 import numpy as np
 from .types import IKJoint
 from scipy.optimize import minimize, OptimizeResult, Bounds
+import warnings
 
 
 def gd(
@@ -88,10 +89,11 @@ def gd(
             options={"maxiter": maxiter, "ftol": rtol},
         )
 
+        if not result.success:
+            warnings.warn(f"L-BFGS-B terminated abnormally with message `{result.message}`.")
+
         scores = np.array([x.score() for x in targets])
         if np.any(scores > atols):
-            if not result.success:
-                raise RuntimeError(f"IK failed. Reason: {result.message}")
 
             raise RuntimeError(
                 f"IK failed. Reason: Local minimum doesn't reach one or more targets."

--- a/skbot/inverse_kinematics/gradient_descent.py
+++ b/skbot/inverse_kinematics/gradient_descent.py
@@ -98,4 +98,5 @@ def gd(
     for joint, value in zip(joints, result.x):
         joint.param = value
 
+    joint_values = np.array([j.param for j in joints])
     return joint_values

--- a/skbot/inverse_kinematics/targets.py
+++ b/skbot/inverse_kinematics/targets.py
@@ -14,7 +14,7 @@ class Target:
     def score(self):
         raise NotImplementedError
 
-    def usage_count(self, joint: tf.Link):
+    def usage_count(self, joint: tf.Link) -> int:
         """The number of occurences of a link within a chain of links"""
         occurences = 0
 
@@ -26,7 +26,7 @@ class Target:
 
         return occurences
 
-    def uses(self, joint: tf.Link):
+    def uses(self, joint: tf.Link) -> bool:
         """Check if joint exists in this goals chain."""
 
         for link in self._chain:

--- a/skbot/inverse_kinematics/targets.py
+++ b/skbot/inverse_kinematics/targets.py
@@ -77,6 +77,8 @@ class Target:
         for link in self._chain:
             if link is joint:
                 return True
+            elif isinstance(link, tf.InvertLink) and link._forward_link is joint:
+                return True
         return False
 
 
@@ -127,6 +129,8 @@ class PositionTarget(Target):
 
         if norm is None:
             self.norm = np.linalg.norm
+        else:
+            self.norm = norm
 
     def score(self):
         current_pos = self.static_position
@@ -203,7 +207,7 @@ class RotationTarget(Target):
         if self.static_frame.ndim == 3:
             value = np.clip((trace - 1) / 2, -1, 1)
             theta = np.arccos(value)
-        elif self.static_frame.ndim == 3:
+        elif self.static_frame.ndim == 2:
             value = np.clip(trace / 2, -1, 1)
             theta = np.arccos(value)
         else:

--- a/skbot/inverse_kinematics/targets.py
+++ b/skbot/inverse_kinematics/targets.py
@@ -118,8 +118,10 @@ class PositionTarget(Target):
         static_frame: tf.Frame,
         dynamic_frame: tf.Frame,
         norm: Callable[[np.ndarray], float] = None,
+        *,
+        atol: float = 1e-3,
     ) -> None:
-        super().__init__(static_frame, dynamic_frame)
+        super().__init__(static_frame, dynamic_frame, atol=atol)
         self.static_position = np.asarray(static_position)
         self.dynamic_position = np.asarray(dynamic_position)
 
@@ -163,6 +165,8 @@ class RotationTarget(Target):
         desired_rotation: Union[tf.Link, List[tf.Link]],
         static_frame: tf.Frame,
         dynamic_frame: tf.Frame,
+        *,
+        atol: float = 1e-3,
     ) -> None:
         parent_dim = static_frame.ndim
         child_dim = dynamic_frame.ndim
@@ -171,7 +175,7 @@ class RotationTarget(Target):
         if parent_dim not in [2, 3]:
             raise NotImplementedError("Only 2D and 3D is currently supported.")
 
-        super().__init__(static_frame, dynamic_frame)
+        super().__init__(static_frame, dynamic_frame, atol=atol)
 
         if isinstance(desired_rotation, tf.Link):
             self.desired_rotation = [desired_rotation]

--- a/skbot/inverse_kinematics/targets.py
+++ b/skbot/inverse_kinematics/targets.py
@@ -103,4 +103,4 @@ class RotationTarget(Target):
         else:
             theta = np.arccos(trace / 2)
 
-        return theta
+        return np.pi - abs(theta - np.pi)

--- a/skbot/inverse_kinematics/targets.py
+++ b/skbot/inverse_kinematics/targets.py
@@ -1,0 +1,106 @@
+from numpy.typing import ArrayLike
+from typing import Callable, List, Union
+import numpy as np
+from .. import transform as tf
+from ..transform._utils import angle_between
+
+
+class Target:
+    def __init__(self, static_frame: tf.Frame, dynamic_frame: tf.Frame) -> None:
+        self.static_frame = static_frame
+        self.dynamic_frame = dynamic_frame
+        self._chain = self.static_frame.links_between(self.dynamic_frame)
+
+    def score(self):
+        raise NotImplementedError
+
+    def usage_count(self, joint: tf.Link):
+        """The number of occurences of a link within a chain of links"""
+        occurences = 0
+
+        for link in self._chain:
+            if link is joint:
+                occurences += 1
+            elif isinstance(link, tf.InvertLink) and link._forward_link is joint:
+                occurences += 1
+
+        return occurences
+
+    def uses(self, joint: tf.Link):
+        """Check if joint exists in this goals chain."""
+
+        for link in self._chain:
+            if link is joint:
+                return True
+        return False
+
+
+class PositionTarget(Target):
+    def __init__(
+        self,
+        static_position: ArrayLike,
+        dynamic_position: ArrayLike,
+        static_frame: tf.Frame,
+        dynamic_frame: tf.Frame,
+        norm: Callable[[np.ndarray], float] = None,
+    ) -> None:
+        super().__init__(static_frame, dynamic_frame)
+        self.static_position = np.asarray(static_position)
+        self.dynamic_position = np.asarray(dynamic_position)
+
+        if norm is None:
+            self.norm = np.linalg.norm
+
+    def score(self):
+        current_pos = self.static_position
+        for link in self._chain:
+            current_pos = link.transform(current_pos)
+
+        return self.norm(self.dynamic_position - current_pos)
+
+
+class RotationTarget(Target):
+    def __init__(
+        self,
+        desired_rotation: Union[tf.Link, List[tf.Link]],
+        static_frame: tf.Frame,
+        dynamic_frame: tf.Frame,
+    ) -> None:
+        parent_dim = static_frame.ndim
+        child_dim = dynamic_frame.ndim
+        if parent_dim != child_dim:
+            raise NotImplementedError("Projected Targets are not supported yet.")
+        if parent_dim not in [2, 3]:
+            raise NotImplementedError("Only 2D and 3D is currently supported.")
+
+        super().__init__(static_frame, dynamic_frame)
+
+        if isinstance(desired_rotation, tf.Link):
+            self.desired_rotation = [desired_rotation]
+        else:
+            self.desired_rotation = desired_rotation
+        self.desired_rotation = tf.simplify_links(self.desired_rotation)
+        self.desired_rotation = [
+            x for x in self.desired_rotation if not isinstance(x, tf.Translation)
+        ]
+
+    def score(self):
+        basis = np.eye(self.static_frame.ndim)
+
+        desired_basis = basis
+        for link in self.desired_rotation:
+            desired_basis = link.transform(desired_basis)
+
+        reduced = tf.simplify_links(self._chain)
+        reduced = [x for x in reduced if not isinstance(x, tf.Translation)]
+        actual_basis = basis
+        for link in reduced:
+            actual_basis = link.transform(actual_basis)
+
+        trace = np.trace(desired_basis @ actual_basis.T)
+        if self.static_frame.ndim == 3:
+            theta = np.arccos((trace - 1) / 2)
+        else:
+            theta = np.arccos(trace / 2)
+
+        return theta

--- a/skbot/inverse_kinematics/targets.py
+++ b/skbot/inverse_kinematics/targets.py
@@ -103,4 +103,4 @@ class RotationTarget(Target):
         else:
             theta = np.arccos(trace / 2)
 
-        return np.pi - abs(theta - np.pi)
+        return theta

--- a/skbot/inverse_kinematics/types.py
+++ b/skbot/inverse_kinematics/types.py
@@ -1,0 +1,5 @@
+from typing import Union
+
+from .. import transform as tf
+
+IKJoint = Union[tf.PrismaticJoint, tf.RotationalJoint]

--- a/skbot/transform/__init__.py
+++ b/skbot/transform/__init__.py
@@ -75,6 +75,12 @@ Available Transformations
     RotationalJoint
     PrismaticJoint
 
+.. rubric:: 2D Links
+    :template: transform_class.rst
+    :toctree:
+
+    AngleJoint
+
 .. rubric:: Other Links
 
 .. autosummary::
@@ -121,7 +127,7 @@ from .utils3d import (
     QuaternionRotation,
     RotvecRotation,
 )
-from .joints import RotationalJoint, PrismaticJoint
+from .joints import RotationalJoint, PrismaticJoint, AngleJoint
 
 from . import metrics
 from .simplfy import simplify_links
@@ -136,6 +142,8 @@ __all__ = [
     "Rotation",
     "Translation",
     "PerspectiveProjection",
+    # 2D Links
+    "AngleJoint",
     # 3D Links
     "EulerRotation",
     "QuaternionRotation",

--- a/skbot/transform/__init__.py
+++ b/skbot/transform/__init__.py
@@ -85,6 +85,15 @@ Available Transformations
     CompundLink
     InvertLink
 
+Functions
+---------
+
+.. autosummary::
+    :toctree:
+
+    simplify_links
+
+
 """
 
 from .base import (
@@ -115,6 +124,7 @@ from .utils3d import (
 from .joints import RotationalJoint, PrismaticJoint
 
 from . import metrics
+from .simplfy import simplify_links
 
 __all__ = [
     # Core Classes for Frame Management
@@ -144,4 +154,5 @@ __all__ = [
     "reflect",
     "shear",
     "scale",
+    "simplify_links",
 ]

--- a/skbot/transform/__init__.py
+++ b/skbot/transform/__init__.py
@@ -76,6 +76,8 @@ Available Transformations
     PrismaticJoint
 
 .. rubric:: 2D Links
+
+.. autosummary::
     :template: transform_class.rst
     :toctree:
 

--- a/skbot/transform/_utils.py
+++ b/skbot/transform/_utils.py
@@ -50,11 +50,11 @@ def scalar_project(
 def angle_between(
     vec_a: ArrayLike, vec_b: ArrayLike, *, axis: int = -1, eps=1e-10
 ) -> np.ndarray:
-    """Computes the angle from a to b (in a right-handed frame)
+    """Computes the angle from a to b
 
     Notes
     -----
-    Implementation is based on this StackOverflow post:
+    Implementation is based on this post:
     https://scicomp.stackexchange.com/a/27694
     """
 
@@ -75,6 +75,11 @@ def angle_between(
 
     mask = len_c > len_b
     mu = np.where(mask, len_b - (len_a - len_c), len_c - (len_a - len_b))
+
+    # added after discussion in
+    # https://stackoverflow.com/q/69453679/
+    mask = np.abs(mu) < eps
+    mu = np.where(mask, 0, mu)
 
     numerator = ((len_a - len_b) + len_c) * mu
     denominator = (len_a + (len_b + len_c)) * ((len_a - len_c) + len_b)

--- a/skbot/transform/affine.py
+++ b/skbot/transform/affine.py
@@ -139,6 +139,9 @@ class Rotation(AffineLink):
     -----
     Implements __inverse_transform__.
 
+    If you wish to initialize a rotation that rotates u onto v, and both are of
+    same length, you can use ``tf.Rotation(u+v, v)``.
+
     """
 
     def __init__(self, u: ArrayLike, v: ArrayLike, *, axis: int = -1) -> None:

--- a/skbot/transform/joints.py
+++ b/skbot/transform/joints.py
@@ -107,6 +107,8 @@ class AngleJoint(Rotation):
             angle = angle / 360 * 2 * np.pi
 
         self.param = angle
+        self.upper_limit = upper_limit
+        self.lower_limit = lower_limit
 
     @property
     def param(self) -> float:

--- a/skbot/transform/simplfy.py
+++ b/skbot/transform/simplfy.py
@@ -128,12 +128,6 @@ def simplify_links(
         while idx < len(links):
             link = links[idx]
 
-            # skip if link should not be modified
-            if link in keep_links:
-                improved_links.append(link)
-                idx += 1
-                continue
-
             if not isinstance(link, Translation):
                 improved_links.append(link)
                 idx += 1
@@ -142,9 +136,6 @@ def simplify_links(
             translations: List[Translation] = list()
             for sub_link in links[idx:]:
                 if not isinstance(sub_link, Translation):
-                    break
-
-                if sub_link in keep_links:
                     break
 
                 translations.append(sub_link)

--- a/skbot/transform/simplfy.py
+++ b/skbot/transform/simplfy.py
@@ -158,7 +158,6 @@ def simplify_links(
 
         return improved_links
 
-
     def sort_links(links: List[Link]) -> List[Link]:
         improved_links: List[Link] = [x for x in links]
 
@@ -167,15 +166,15 @@ def simplify_links(
             repeat = False
             for idx in range(len(improved_links) - 1):
                 link = improved_links[idx]
-                next_link = improved_links[idx+1]
+                next_link = improved_links[idx + 1]
 
                 if isinstance(link, Rotation) and isinstance(next_link, Translation):
                     vector = next_link.amount * next_link.direction
                     vector = link.__inverse_transform__(vector)
-                    
+
                     improved_links[idx + 1] = improved_links[idx]
                     improved_links[idx] = Translation(vector)
-                    
+
                     repeat = True
                     continue
 
@@ -184,8 +183,8 @@ def simplify_links(
     improved_links = simplify(links)
 
     subchains: List[List[Link]] = list()
-    keepsies:List[Link] = list()
-    current_subchain:List[Link] = list()
+    keepsies: List[Link] = list()
+    current_subchain: List[Link] = list()
     for link in improved_links:
         if link in keep_links:
             keepsies.append(link)
@@ -194,14 +193,14 @@ def simplify_links(
         else:
             current_subchain.append(link)
     subchains.append(current_subchain)
-    
-    improved_chains:List[List[Link]] = list()
+
+    improved_chains: List[List[Link]] = list()
     for subchain in subchains:
         improved_links = sort_links(subchain)
         improved_links = combine_translations(improved_links)
         improved_chains.append(improved_links)
 
-    improved_chain:List[Link] = list()
+    improved_chain: List[Link] = list()
     for chain, keepsie in zip(improved_chains, keepsies):
         improved_chain += chain
         improved_chain += [keepsie]

--- a/skbot/transform/simplfy.py
+++ b/skbot/transform/simplfy.py
@@ -1,0 +1,163 @@
+from typing import List
+from .base import CompundLink, Link, InvertLink
+from .affine import AffineCompound, Translation, Rotation
+import numpy as np
+
+
+def simplify_links(
+    links: List[Link], *, keep_links: List[Link] = None, eps: float = 1e-16
+) -> List[Link]:
+    """Simplify a transformation sequence.
+
+    .. currentmodule:: skbot.transform
+
+    This function attempts to optimize the given transformation sequence by
+    reducing the number of transformations involved. For this it may replace or
+    modify any link in the sequence with the exception of those listed in
+    ``keep_links``. Concretely it does the following modifications:
+
+    - It (recursively) flattens :class:`CompoundLinks <CompundLink>`.
+    - It replaces double inversions with the original link.
+    - It drops 0 degree :class:`Rotations <Rotation>` (identities).
+    - It drops 0 amount :class:`Translations <Translation>` (identities).
+    - It combines series of translations into a single translation.
+
+    .. versionadded:: 0.10.0
+
+    Parameters
+    ----------
+    links : List[Link]
+        The list of links to simplify.
+    keep_links : List[Link]
+        A list list of links that - if present - should not be simplified.
+    eps : float
+        The number below which angles and translations are interpreted as 0.
+        Defaults to ``1e-16``.
+
+    Returns
+    -------
+    improved_links : List[Link]
+        A new list of links that is a simplified version of the initial list.
+    """
+
+    if keep_links is None:
+        keep_links = list()
+
+    def simplify(links: List[Link]) -> List[Link]:
+        improved_links: List[Link] = list()
+
+        for idx in range(len(links)):
+            link = links[idx]
+
+            # skip if link should not be modified
+            if link in keep_links:
+                improved_links.append(link)
+                continue
+
+            # resolve inversions
+            if isinstance(link, InvertLink):
+                inverted_link = link._forward_link
+
+                # still don't touch keep links
+                if inverted_link in keep_links:
+                    improved_links.append(link)
+                    continue
+
+                # double inverse
+                if isinstance(inverted_link, InvertLink):
+                    improved_links.append(inverted_link._forward_link)
+                    continue
+
+                # inverted compound link
+                if isinstance(inverted_link, (CompundLink, AffineCompound)):
+                    for sub_link in reversed(inverted_link._links):
+                        improved_links.append(InvertLink(sub_link))
+                    continue
+
+                # inverted translation
+                if isinstance(inverted_link, Translation):
+                    resolved = Translation(
+                        inverted_link.direction,
+                        amount=-inverted_link.amount,
+                        axis=inverted_link._axis,
+                    )
+                    improved_links.append(resolved)
+                    continue
+
+                # inverted rotation
+                if isinstance(inverted_link, Rotation):
+                    angle = inverted_link.angle
+                    resolved = Rotation(
+                        inverted_link._u,
+                        inverted_link._u_ortho,
+                        axis=inverted_link._axis,
+                    )
+                    resolved.angle = -angle
+                    improved_links.append(resolved)
+                    continue
+
+            # unpack compound links
+            if isinstance(link, (CompundLink, AffineCompound)):
+                for sub_link in link._links:
+                    improved_links.append(sub_link)
+                continue
+
+            # drop identity translations
+            if isinstance(link, Translation) and abs(link.amount) < eps:
+                continue
+
+            # drop identity rotations
+            if isinstance(link, Rotation) and abs(link.angle) < eps:
+                continue
+
+            # no improvements for this link
+            improved_links.append(link)
+
+        if len(improved_links) != len(links):
+            improved_links = simplify(improved_links)
+        elif any([a != b for a, b in zip(links, improved_links)]):
+            improved_links = simplify(improved_links)
+
+        return improved_links
+
+    def combine_translations(links: List[Link]) -> List[Link]:
+        improved_links: List[Link] = list()
+
+        idx = 0
+        while idx < len(links):
+            link = links[idx]
+
+            # skip if link should not be modified
+            if link in keep_links:
+                improved_links.append(link)
+                idx += 1
+                continue
+
+            if not isinstance(link, Translation):
+                improved_links.append(link)
+                idx += 1
+                continue
+
+            translations: List[Translation] = list()
+            for sub_link in links[idx:]:
+                if not isinstance(sub_link, Translation):
+                    break
+
+                if sub_link in keep_links:
+                    break
+
+                translations.append(sub_link)
+
+            new_direction = np.zeros(link.parent_dim)
+            for sub_link in translations:
+                new_direction += sub_link.amount * sub_link.direction
+
+            improved_links.append(Translation(new_direction))
+            idx += len(translations)
+
+        return improved_links
+
+    improved_links = simplify(links)
+    improved_links = combine_translations(improved_links)
+
+    return improved_links

--- a/tests/ignition/sdf/v18/panda_cam.sdf
+++ b/tests/ignition/sdf/v18/panda_cam.sdf
@@ -1,0 +1,31 @@
+<?xml version="1.0" ?>
+<sdf version="1.8">
+    <world name="panda_cam">
+        <model name="camera_model">
+            <pose>1 0 0.5 0 0 0</pose>
+            <link name="camera_link">
+                <sensor name="camera_sensor" type="camera">
+                    <camera>
+                        <horizontal_fov>1.13446</horizontal_fov>
+                        <image>
+                            <width>1920</width>
+                            <height>1080</height>
+                        </image>
+                        <clip>
+                            <near>0.01</near>
+                            <far>100</far>
+                        </clip>
+                    </camera>
+                </sensor>
+            </link>
+            <joint name="connect" type="fixed">
+                <parent>world</parent>
+                <child>camera_link</child>
+            </joint>
+        </model>
+        <include>
+            <uri>https://fuel.ignitionrobotics.org/1.0/AndrejOrsula/models/panda</uri>
+            <name>panda</name>
+        </include>
+    </world>
+</sdf>

--- a/tests/inverse_kinematics/conftest.py
+++ b/tests/inverse_kinematics/conftest.py
@@ -22,6 +22,8 @@ def panda():
         if isinstance(link, (tf.RotationalJoint, tf.PrismaticJoint)):
             joints.append(link)
 
+    for value, joint in zip([0, -0.785,0, -2.356, 0, 1.571, 0.785], reversed(joints)):
+        joint.param = value
     return base_frame, joints
 
 

--- a/tests/inverse_kinematics/conftest.py
+++ b/tests/inverse_kinematics/conftest.py
@@ -39,3 +39,18 @@ def double_pendulum():
             joints.append(link)
 
     return base_frame, joints
+
+
+@pytest.fixture()
+def circle_bot():
+    world = tf.Frame(3, name="world")
+    ellbow = tf.Frame(3, name="ellbow")
+    tool = tf.Frame(3, name="tool")
+
+    rotate = tf.RotationalJoint((0, 0, 1), angle=0)
+    reach = tf.PrismaticJoint((-1, 0, 0), upper_limit=10, lower_limit=-10)
+
+    rotate(world, ellbow)
+    reach(ellbow, tool)
+
+    return world, [rotate, reach]

--- a/tests/inverse_kinematics/conftest.py
+++ b/tests/inverse_kinematics/conftest.py
@@ -22,7 +22,7 @@ def panda():
         if isinstance(link, (tf.RotationalJoint, tf.PrismaticJoint)):
             joints.append(link)
 
-    for value, joint in zip([0, -0.785,0, -2.356, 0, 1.571, 0.785], reversed(joints)):
+    for value, joint in zip([0, -0.785, 0, -2.356, 0, 1.571, 0.785], reversed(joints)):
         joint.param = value
     return base_frame, joints
 

--- a/tests/inverse_kinematics/conftest.py
+++ b/tests/inverse_kinematics/conftest.py
@@ -1,4 +1,3 @@
-from skbot.transform import base
 import pytest
 import skbot.ignition as ign
 import skbot.transform as tf

--- a/tests/inverse_kinematics/test_ccd.py
+++ b/tests/inverse_kinematics/test_ccd.py
@@ -168,7 +168,6 @@ def test_multi_frame_ccd(panda):
 
     tool_origin = tool_frame.transform((0, 0, 0), base_frame)
 
-    
     expected = np.zeros(len(joints))
     for idx, joint in enumerate(joints):
         expected[idx] = joint.param

--- a/tests/inverse_kinematics/test_ccd.py
+++ b/tests/inverse_kinematics/test_ccd.py
@@ -117,7 +117,57 @@ def test_pendulum(double_pendulum):
     final_pos = tool_frame.transform((0, 0, 0), base_frame)
 
     assert np.allclose(final_pos, root_pos, atol=0.001)
-    # assert np.allclose(angles, expected)
+
+
+def test_pendulum_legacy(double_pendulum):
+    base_frame: tf.Frame
+    joints: List[joint_types]
+    base_frame, joints = double_pendulum
+    tool_frame = base_frame.find_frame(".../lower_link")
+
+    for joint in joints:
+        joint.param = (joint.upper_limit + joint.lower_limit) / 4
+
+    root_pos = tool_frame.transform((0, 0, 0), base_frame)
+    expected = np.zeros(len(joints))
+
+    for idx, joint in enumerate(joints):
+        expected[idx] = joint.param
+        joint.param = (joint.upper_limit + joint.lower_limit) / 2
+
+    angles = ik.ccd((0, 0, 0), root_pos, tool_frame, base_frame, joints)
+    final_pos = tool_frame.transform((0, 0, 0), base_frame)
+
+    assert np.allclose(final_pos, root_pos, atol=0.001)
+
+
+def test_pendulum_legacy_kwargs(double_pendulum):
+    base_frame: tf.Frame
+    joints: List[joint_types]
+    base_frame, joints = double_pendulum
+    tool_frame = base_frame.find_frame(".../lower_link")
+
+    for joint in joints:
+        joint.param = (joint.upper_limit + joint.lower_limit) / 4
+
+    root_pos = tool_frame.transform((0, 0, 0), base_frame)
+    expected = np.zeros(len(joints))
+
+    for idx, joint in enumerate(joints):
+        expected[idx] = joint.param
+        joint.param = (joint.upper_limit + joint.lower_limit) / 2
+
+    angles = ik.ccd(
+        [],
+        pointA=(0, 0, 0),
+        pointB=root_pos,
+        frameA=tool_frame,
+        frameB=base_frame,
+        cycle_links=joints,
+    )
+    final_pos = tool_frame.transform((0, 0, 0), base_frame)
+
+    assert np.allclose(final_pos, root_pos, atol=0.001)
 
 
 def test_ccd_maxiter(double_pendulum):

--- a/tests/inverse_kinematics/test_ccd.py
+++ b/tests/inverse_kinematics/test_ccd.py
@@ -110,6 +110,7 @@ def test_ccd_linesearch_maxiter(double_pendulum):
             (0, 0, 0), root_pos, tool_frame, base_frame, joints, line_search_maxiter=1
         )
 
+
 def test_multi_frame_ccd(panda):
     base_frame: tf.Frame
     joints: List[joint_types]
@@ -131,7 +132,7 @@ def test_multi_frame_ccd(panda):
         [base_frame, base_frame],
         joints,
         metric=lambda x, y: np.linalg.norm(x - y, ord=4),
-        weights=[1, 0.7]
+        weights=[1, 0.7],
     )
     final_pos = tool_frame.transform((0, 0, 0), base_frame)
 

--- a/tests/inverse_kinematics/test_ccd.py
+++ b/tests/inverse_kinematics/test_ccd.py
@@ -165,26 +165,28 @@ def test_multi_frame_ccd(panda):
     tool_frame = base_frame.find_frame(".../panda_link8")
 
     root_pos = tool_frame.transform((0, 0, 0), base_frame)
-    root_ori = tool_frame.transform((1, 0, 0), base_frame)
-    expected = np.zeros(len(joints))
 
+    tool_origin = tool_frame.transform((0, 0, 0), base_frame)
+
+    
+    expected = np.zeros(len(joints))
     for idx, joint in enumerate(joints):
         expected[idx] = joint.param
-        joint.param = (joint.upper_limit - joint.lower_limit) / 2
+        joint.param += 0.2
 
     targets = [
         ik.PositionTarget((0, 0, 0), root_pos, tool_frame, base_frame),
         ik.RotationTarget(
-            tf.EulerRotation("Y", 90, degrees=True), tool_frame, base_frame
+            tf.EulerRotation("X", 180, degrees=True), tool_frame, base_frame
         ),
     ]
 
-    angles = ik.ccd(
-        targets,
-        joints,
-        weights=[1, 0.7],
-    )
-    final_pos = tool_frame.transform((0, 0, 0), base_frame)
+    ik.ccd(targets, joints, atol=0.01)
 
+    tool_origin = tool_frame.transform((0, 0, 0), base_frame)
+    tool_facing = tool_frame.transform((0, 0, 1), base_frame)
+    final_ori = tool_facing - tool_origin
+    assert np.allclose(final_ori, (0, 0, -1), atol=0.001)
+
+    final_pos = tool_frame.transform((0, 0, 0), base_frame)
     assert np.allclose(final_pos, root_pos, atol=0.001)
-    # assert np.allclose(angles, expected)

--- a/tests/inverse_kinematics/test_ccd.py
+++ b/tests/inverse_kinematics/test_ccd.py
@@ -160,35 +160,36 @@ def test_ccd_linesearch_maxiter(panda):
         ik.ccd(targets, joints, line_search_maxiter=1)
 
 
-def test_multi_frame_ccd(panda):
-    base_frame: tf.Frame
-    joints: List[joint_types]
-    base_frame, joints = panda
-    tool_frame = base_frame.find_frame(".../panda_link8")
+# # Multi-Frame (pos+rot) doesn't work with CCD (yet?)
+# def test_multi_frame_ccd(panda):
+#     base_frame: tf.Frame
+#     joints: List[joint_types]
+#     base_frame, joints = panda
+#     tool_frame = base_frame.find_frame(".../panda_link8")
 
-    root_pos = tool_frame.transform((0, 0, 0), base_frame)
+#     root_pos = tool_frame.transform((0, 0, 0), base_frame)
 
-    expected = np.zeros(len(joints))
-    for idx, joint in enumerate(joints):
-        expected[idx] = joint.angle
-        joint.angle += 0.2
+#     expected = np.zeros(len(joints))
+#     for idx, joint in enumerate(joints):
+#         expected[idx] = joint.angle
+#         joint.angle += 0.2
 
-    targets = [
-        ik.RotationTarget(
-            tf.EulerRotation("X", 180, degrees=True), tool_frame, base_frame
-        ),
-        ik.PositionTarget((0, 0, 0), root_pos, tool_frame, base_frame),
-    ]
+#     targets = [
+#         ik.RotationTarget(
+#             tf.EulerRotation("X", 180, degrees=True), tool_frame, base_frame
+#         ),
+#         ik.PositionTarget((0, 0, 0), root_pos, tool_frame, base_frame),
+#     ]
 
-    ik.ccd(targets, joints, atol=0.01)
+#     ik.ccd(targets, joints, atol=0.01)
 
-    tool_origin = tool_frame.transform((0, 0, 0), base_frame)
-    tool_facing = tool_frame.transform((0, 0, 1), base_frame)
-    final_ori = tool_facing - tool_origin
-    assert np.allclose(final_ori, (0, 0, -1), atol=0.001)
+#     tool_origin = tool_frame.transform((0, 0, 0), base_frame)
+#     tool_facing = tool_frame.transform((0, 0, 1), base_frame)
+#     final_ori = tool_facing - tool_origin
+#     assert np.allclose(final_ori, (0, 0, -1), atol=0.001)
 
-    final_pos = tool_frame.transform((0, 0, 0), base_frame)
-    assert np.allclose(final_pos, root_pos, atol=0.001)
+#     final_pos = tool_frame.transform((0, 0, 0), base_frame)
+#     assert np.allclose(final_pos, root_pos, atol=0.001)
 
 
 def test_camera_steering():

--- a/tests/inverse_kinematics/test_ccd.py
+++ b/tests/inverse_kinematics/test_ccd.py
@@ -2,9 +2,11 @@ from typing import List
 import pytest
 import skbot.inverse_kinematics as ik
 import skbot.transform as tf
+import skbot.ignition as ign
 from typing import List
 import numpy as np
 from skbot.inverse_kinematics.types import IKJoint as joint_types
+from pathlib import Path
 
 
 def test_panda(panda):
@@ -166,18 +168,16 @@ def test_multi_frame_ccd(panda):
 
     root_pos = tool_frame.transform((0, 0, 0), base_frame)
 
-    tool_origin = tool_frame.transform((0, 0, 0), base_frame)
-
     expected = np.zeros(len(joints))
     for idx, joint in enumerate(joints):
         expected[idx] = joint.angle
         joint.angle += 0.2
 
     targets = [
-        ik.PositionTarget((0, 0, 0), root_pos, tool_frame, base_frame),
         ik.RotationTarget(
             tf.EulerRotation("X", 180, degrees=True), tool_frame, base_frame
         ),
+        ik.PositionTarget((0, 0, 0), root_pos, tool_frame, base_frame),
     ]
 
     ik.ccd(targets, joints, atol=0.01)
@@ -189,3 +189,42 @@ def test_multi_frame_ccd(panda):
 
     final_pos = tool_frame.transform((0, 0, 0), base_frame)
     assert np.allclose(final_pos, root_pos, atol=0.001)
+
+
+def test_camera_steering():
+    model_file = (
+        Path(__file__).parents[1] / "ignition" / "sdf" / "v18" / "panda_cam.sdf"
+    )
+    sdf_string = model_file.read_text()
+
+    generic_sdf = ign.sdformat.loads_generic(sdf_string)
+    world_sdf = generic_sdf.worlds[0]
+
+    frames = world_sdf.declared_frames()
+    world_sdf.to_dynamic_graph(frames)
+
+    world_frame = frames["world"]
+    px_space = frames["camera_model::camera_link::camera_sensor::pixel_space"]
+    base_frame = frames["panda::panda_link0"]
+    tool_frame = frames["panda::panda_link8"]
+
+    joints = list()
+    for link in tool_frame.links_between(base_frame):
+        if isinstance(link, (tf.RotationalJoint, tf.PrismaticJoint)):
+            joints.append(link)
+
+    for value, joint in zip([0, -0.785, 0, -2.356, 0, 1.571, 0.785], reversed(joints)):
+        joint.angle = value
+
+    targets = [ik.PositionTarget((0, 0, 0), (1920 / 3, 1080 / 3), tool_frame, px_space)]
+    ik.ccd(targets, joints)
+
+    for target in targets:
+        assert target.score() < target.atol
+
+    result_pos = targets[0].static_frame.transform(
+        targets[0].static_position, targets[0].dynamic_frame
+    )
+    target_pos = targets[0].dynamic_position
+
+    assert np.allclose(result_pos, target_pos, 0.001)

--- a/tests/inverse_kinematics/test_ccd.py
+++ b/tests/inverse_kinematics/test_ccd.py
@@ -1,9 +1,13 @@
 from typing import List
 import pytest
 import skbot.inverse_kinematics as ik
+from skbot.inverse_kinematics import targets
+from skbot.inverse_kinematics.targets import PositionTarget
 import skbot.transform as tf
 from typing import Union, List
 import numpy as np
+
+from skbot.transform.utils3d import EulerRotation
 
 
 joint_types = Union[tf.RotationalJoint, tf.PrismaticJoint]
@@ -22,11 +26,39 @@ def test_panda(panda):
         expected[idx] = joint.param
         joint.param = (joint.upper_limit - joint.lower_limit) / 2
 
-    angles = ik.ccd((0, 0, 0), root_pos, tool_frame, base_frame, joints)
+    targets = [ik.PositionTarget((0, 0, 0), root_pos, tool_frame, base_frame)]
+    angles = ik.ccd(targets, joints)
     final_pos = tool_frame.transform((0, 0, 0), base_frame)
 
     assert np.allclose(final_pos, root_pos, atol=0.001)
     # assert np.allclose(angles, expected)
+
+
+def test_panda_orientation(panda):
+    base_frame: tf.Frame
+    joints: List[joint_types]
+    base_frame, joints = panda
+    tool_frame = base_frame.find_frame(".../panda_link8")
+
+    root_pos = tool_frame.transform((0, 0, 0), base_frame)
+    expected = np.zeros(len(joints))
+
+    for idx, joint in enumerate(joints):
+        expected[idx] = joint.param
+        joint.param = (joint.upper_limit - joint.lower_limit) / 2
+
+    targets = [
+        ik.RotationTarget(
+            tf.EulerRotation("Y", 90, degrees=True), tool_frame, base_frame
+        )
+    ]
+    ik.ccd(targets, joints)
+
+    tool_origin = tool_frame.transform((0, 0, 0), base_frame)
+    tool_facing = tool_frame.transform((1, 0, 0), base_frame)
+    final_ori = tool_facing - tool_origin
+
+    assert np.allclose(final_ori, (0, 0, -1), atol=0.001)
 
 
 def test_custom_distance(panda):
@@ -42,11 +74,16 @@ def test_custom_distance(panda):
         expected[idx] = joint.param
         joint.param = (joint.upper_limit - joint.lower_limit) / 2
 
+    targets = [
+        ik.PositionTarget(
+            static_position=(0, 0, 0),
+            dynamic_position=root_pos,
+            static_frame=tool_frame,
+            dynamic_frame=base_frame,
+        )
+    ]
     angles = ik.ccd(
-        (0, 0, 0),
-        root_pos,
-        tool_frame,
-        base_frame,
+        targets,
         joints,
         metric=lambda x, y: np.linalg.norm(x - y, ord=4),
     )
@@ -72,7 +109,15 @@ def test_pendulum(double_pendulum):
         expected[idx] = joint.param
         joint.param = (joint.upper_limit - joint.lower_limit) / 2
 
-    angles = ik.ccd((0, 0, 0), root_pos, tool_frame, base_frame, joints)
+    targets = [
+        ik.PositionTarget(
+            static_position=(0, 0, 0),
+            dynamic_position=root_pos,
+            static_frame=tool_frame,
+            dynamic_frame=base_frame,
+        )
+    ]
+    angles = ik.ccd(targets, joints)
     final_pos = tool_frame.transform((0, 0, 0), base_frame)
 
     assert np.allclose(final_pos, root_pos, atol=0.001)
@@ -90,8 +135,10 @@ def test_ccd_maxiter(double_pendulum):
     for joint in joints:
         joint.param = (joint.upper_limit - joint.lower_limit) / 2
 
+    targets = [ik.PositionTarget((0, 0, 0), root_pos, tool_frame, base_frame)]
+
     with pytest.raises(RuntimeError):
-        ik.ccd((0, 0, 0), root_pos, tool_frame, base_frame, joints, maxiter=0)
+        ik.ccd(targets, joints, maxiter=0)
 
 
 def test_ccd_linesearch_maxiter(double_pendulum):
@@ -105,10 +152,10 @@ def test_ccd_linesearch_maxiter(double_pendulum):
     for joint in joints:
         joint.param = (joint.upper_limit - joint.lower_limit) / 2
 
+    targets = [ik.PositionTarget((0, 0, 0), root_pos, tool_frame, base_frame)]
+
     with pytest.raises(RuntimeError):
-        ik.ccd(
-            (0, 0, 0), root_pos, tool_frame, base_frame, joints, line_search_maxiter=1
-        )
+        ik.ccd(targets, joints, line_search_maxiter=1)
 
 
 def test_multi_frame_ccd(panda):
@@ -125,13 +172,16 @@ def test_multi_frame_ccd(panda):
         expected[idx] = joint.param
         joint.param = (joint.upper_limit - joint.lower_limit) / 2
 
+    targets = [
+        ik.PositionTarget((0, 0, 0), root_pos, tool_frame, base_frame),
+        ik.RotationTarget(
+            tf.EulerRotation("Y", 90, degrees=True), tool_frame, base_frame
+        ),
+    ]
+
     angles = ik.ccd(
-        [(0, 0, 0), (1, 0, 0)],
-        [root_pos, root_ori],
-        [tool_frame, tool_frame],
-        [base_frame, base_frame],
+        targets,
         joints,
-        metric=lambda x, y: np.linalg.norm(x - y, ord=4),
         weights=[1, 0.7],
     )
     final_pos = tool_frame.transform((0, 0, 0), base_frame)

--- a/tests/inverse_kinematics/test_ccd.py
+++ b/tests/inverse_kinematics/test_ccd.py
@@ -269,45 +269,6 @@ def test_camera_steering():
     for value, joint in zip([0, -0.785, 0, -2.356, 0, 1.571, 0.785], reversed(joints)):
         joint.angle = value
 
-    targets = [ik.PositionTarget((0, 0, 0), (1920 / 3, 1080 / 2), tool_frame, px_space)]
-    ik.ccd(targets, joints)
-
-    for target in targets:
-        assert target.score() < target.atol
-
-    result_pos = targets[0].static_frame.transform(
-        targets[0].static_position, targets[0].dynamic_frame
-    )
-    target_pos = targets[0].dynamic_position
-
-    assert np.allclose(result_pos, target_pos, 0.001)
-
-
-def test_camera_steering():
-    model_file = (
-        Path(__file__).parents[1] / "ignition" / "sdf" / "v18" / "panda_cam.sdf"
-    )
-    sdf_string = model_file.read_text()
-
-    generic_sdf = ign.sdformat.loads_generic(sdf_string)
-    world_sdf = generic_sdf.worlds[0]
-
-    frames = world_sdf.declared_frames()
-    world_sdf.to_dynamic_graph(frames)
-
-    world_frame = frames["world"]
-    px_space = frames["camera_model::camera_link::camera_sensor::pixel_space"]
-    base_frame = frames["panda::panda_link0"]
-    tool_frame = frames["panda::panda_link8"]
-
-    joints = list()
-    for link in tool_frame.links_between(base_frame):
-        if isinstance(link, (tf.RotationalJoint, tf.PrismaticJoint)):
-            joints.append(link)
-
-    for value, joint in zip([0, -0.785, 0, -2.356, 0, 1.571, 0.785], reversed(joints)):
-        joint.angle = value
-
     radius = 10
     angles = np.linspace(0, 2 * np.pi, 100)
     circle_x = radius * np.cos(angles) + 1920 / 2

--- a/tests/inverse_kinematics/test_ccd.py
+++ b/tests/inverse_kinematics/test_ccd.py
@@ -216,7 +216,7 @@ def test_camera_steering():
     for value, joint in zip([0, -0.785, 0, -2.356, 0, 1.571, 0.785], reversed(joints)):
         joint.angle = value
 
-    targets = [ik.PositionTarget((0, 0, 0), (1920 / 3, 1080 / 3), tool_frame, px_space)]
+    targets = [ik.PositionTarget((0, 0, 0), (1920/3, 1080/2), tool_frame, px_space)]
     ik.ccd(targets, joints)
 
     for target in targets:
@@ -228,3 +228,51 @@ def test_camera_steering():
     target_pos = targets[0].dynamic_position
 
     assert np.allclose(result_pos, target_pos, 0.001)
+
+
+def test_camera_steering():
+    model_file = (
+        Path(__file__).parents[1] / "ignition" / "sdf" / "v18" / "panda_cam.sdf"
+    )
+    sdf_string = model_file.read_text()
+
+    generic_sdf = ign.sdformat.loads_generic(sdf_string)
+    world_sdf = generic_sdf.worlds[0]
+
+    frames = world_sdf.declared_frames()
+    world_sdf.to_dynamic_graph(frames)
+
+    world_frame = frames["world"]
+    px_space = frames["camera_model::camera_link::camera_sensor::pixel_space"]
+    base_frame = frames["panda::panda_link0"]
+    tool_frame = frames["panda::panda_link8"]
+
+    joints = list()
+    for link in tool_frame.links_between(base_frame):
+        if isinstance(link, (tf.RotationalJoint, tf.PrismaticJoint)):
+            joints.append(link)
+
+    for value, joint in zip([0, -0.785, 0, -2.356, 0, 1.571, 0.785], reversed(joints)):
+        joint.angle = value
+
+    radius = 10
+    angles = np.linspace(0, 2*np.pi, 100)
+    circle_x = radius * np.cos(angles) + 1920/2
+    circle_y = radius * np.sin(angles) + 1080/2
+    circle = np.stack([circle_x, circle_y], axis=1)
+
+    for point in circle:
+        targets = [ik.PositionTarget((0, 0, 0), point, tool_frame, px_space)]
+        for value, joint in zip([0, -0.785, 0, -2.356, 0, 1.571, 0.785], reversed(joints)):
+            joint.angle = value
+        ik.ccd(targets, joints)
+
+        for target in targets:
+            assert target.score() < target.atol
+
+        result_pos = targets[0].static_frame.transform(
+            targets[0].static_position, targets[0].dynamic_frame
+        )
+        target_pos = targets[0].dynamic_position
+
+        assert np.allclose(result_pos, target_pos, 0.001)

--- a/tests/inverse_kinematics/test_ccd.py
+++ b/tests/inverse_kinematics/test_ccd.py
@@ -23,8 +23,8 @@ def test_panda(panda):
     expected = np.zeros(len(joints))
 
     for idx, joint in enumerate(joints):
-        expected[idx] = joint.param
-        joint.param = (joint.upper_limit - joint.lower_limit) / 2
+        expected[idx] = joint.angle
+        joint.angle = (joint.upper_limit + joint.lower_limit) / 2
 
     targets = [ik.PositionTarget((0, 0, 0), root_pos, tool_frame, base_frame)]
     angles = ik.ccd(targets, joints)
@@ -45,7 +45,7 @@ def test_panda_orientation(panda):
 
     for idx, joint in enumerate(joints):
         expected[idx] = joint.param
-        joint.param = (joint.upper_limit - joint.lower_limit) / 2
+        joint.param = (joint.upper_limit + joint.lower_limit) / 2
 
     targets = [
         ik.RotationTarget(
@@ -100,14 +100,14 @@ def test_pendulum(double_pendulum):
     tool_frame = base_frame.find_frame(".../lower_link")
 
     for joint in joints:
-        joint.param = (joint.upper_limit - joint.lower_limit) / 4
+        joint.param = (joint.upper_limit + joint.lower_limit) / 4
 
     root_pos = tool_frame.transform((0, 0, 0), base_frame)
     expected = np.zeros(len(joints))
 
     for idx, joint in enumerate(joints):
         expected[idx] = joint.param
-        joint.param = (joint.upper_limit - joint.lower_limit) / 2
+        joint.param = (joint.upper_limit + joint.lower_limit) / 2
 
     targets = [
         ik.PositionTarget(
@@ -133,7 +133,7 @@ def test_ccd_maxiter(double_pendulum):
     root_pos = tool_frame.transform((0, 0, 0), base_frame)
 
     for joint in joints:
-        joint.param = (joint.upper_limit - joint.lower_limit) / 2
+        joint.param = (joint.upper_limit + joint.lower_limit) / 2
 
     targets = [ik.PositionTarget((0, 0, 0), root_pos, tool_frame, base_frame)]
 
@@ -150,7 +150,7 @@ def test_ccd_linesearch_maxiter(double_pendulum):
     root_pos = tool_frame.transform((0, 0, 0), base_frame)
 
     for joint in joints:
-        joint.param = (joint.upper_limit - joint.lower_limit) / 2
+        joint.param = (joint.upper_limit + joint.lower_limit) / 2
 
     targets = [ik.PositionTarget((0, 0, 0), root_pos, tool_frame, base_frame)]
 

--- a/tests/inverse_kinematics/test_ccd.py
+++ b/tests/inverse_kinematics/test_ccd.py
@@ -216,7 +216,7 @@ def test_camera_steering():
     for value, joint in zip([0, -0.785, 0, -2.356, 0, 1.571, 0.785], reversed(joints)):
         joint.angle = value
 
-    targets = [ik.PositionTarget((0, 0, 0), (1920/3, 1080/2), tool_frame, px_space)]
+    targets = [ik.PositionTarget((0, 0, 0), (1920 / 3, 1080 / 2), tool_frame, px_space)]
     ik.ccd(targets, joints)
 
     for target in targets:
@@ -256,14 +256,16 @@ def test_camera_steering():
         joint.angle = value
 
     radius = 10
-    angles = np.linspace(0, 2*np.pi, 100)
-    circle_x = radius * np.cos(angles) + 1920/2
-    circle_y = radius * np.sin(angles) + 1080/2
+    angles = np.linspace(0, 2 * np.pi, 100)
+    circle_x = radius * np.cos(angles) + 1920 / 2
+    circle_y = radius * np.sin(angles) + 1080 / 2
     circle = np.stack([circle_x, circle_y], axis=1)
 
     for point in circle:
         targets = [ik.PositionTarget((0, 0, 0), point, tool_frame, px_space)]
-        for value, joint in zip([0, -0.785, 0, -2.356, 0, 1.571, 0.785], reversed(joints)):
+        for value, joint in zip(
+            [0, -0.785, 0, -2.356, 0, 1.571, 0.785], reversed(joints)
+        ):
             joint.angle = value
         ik.ccd(targets, joints)
 

--- a/tests/inverse_kinematics/test_ccd.py
+++ b/tests/inverse_kinematics/test_ccd.py
@@ -157,17 +157,19 @@ def test_pendulum_legacy_kwargs(double_pendulum):
         expected[idx] = joint.param
         joint.param = (joint.upper_limit + joint.lower_limit) / 2
 
-    angles = ik.ccd(
-        [],
-        pointA=(0, 0, 0),
-        pointB=root_pos,
-        frameA=tool_frame,
-        frameB=base_frame,
-        cycle_links=joints,
-    )
+    with pytest.deprecated_call():
+        angles = ik.ccd(
+            [],
+            pointA=(0, 0, 0),
+            pointB=root_pos,
+            frameA=tool_frame,
+            frameB=base_frame,
+            cycle_links=joints,
+            tol=0.01,
+        )
     final_pos = tool_frame.transform((0, 0, 0), base_frame)
 
-    assert np.allclose(final_pos, root_pos, atol=0.001)
+    assert np.allclose(final_pos, root_pos, atol=0.01)
 
 
 def test_ccd_maxiter(double_pendulum):

--- a/tests/inverse_kinematics/test_gd.py
+++ b/tests/inverse_kinematics/test_gd.py
@@ -31,29 +31,29 @@ def test_panda(panda):
     assert np.allclose(final_pos, root_pos, atol=0.001)
 
 
-# def test_panda_orientation(panda):
-#     base_frame: tf.Frame
-#     joints: List[joint_types]
-#     base_frame, joints = panda
-#     tool_frame = base_frame.find_frame(".../panda_link8")
+def test_panda_orientation(panda):
+    base_frame: tf.Frame
+    joints: List[joint_types]
+    base_frame, joints = panda
+    tool_frame = base_frame.find_frame(".../panda_link8")
 
-#     expected = np.zeros(len(joints))
-#     for idx, joint in enumerate(joints):
-#         expected[idx] = joint.param
-#         joint.param = (joint.upper_limit - joint.lower_limit) / 2
+    expected = np.zeros(len(joints))
+    for idx, joint in enumerate(joints):
+        expected[idx] = joint.param
+        joint.param = joint.param + 0.2
 
-#     targets = [
-#         ik.RotationTarget(
-#             tf.EulerRotation("Y", 90, degrees=True), tool_frame, base_frame
-#         )
-#     ]
-#     ik.gd(targets, joints)
+    targets = [
+        ik.RotationTarget(
+            tf.EulerRotation("Y", 90, degrees=True), tool_frame, base_frame
+        )
+    ]
+    ik.gd(targets, joints)
 
-#     tool_origin = tool_frame.transform((0, 0, 0), base_frame)
-#     tool_facing = tool_frame.transform((1, 0, 0), base_frame)
-#     final_ori = tool_facing - tool_origin
+    tool_origin = tool_frame.transform((0, 0, 0), base_frame)
+    tool_facing = tool_frame.transform((1, 0, 0), base_frame)
+    final_ori = tool_facing - tool_origin
 
-#     assert np.allclose(final_ori, (0, 0, -1), atol=0.001)
+    assert np.allclose(final_ori, (0, 0, -1), atol=0.001)
 
 
 def test_pendulum(double_pendulum):

--- a/tests/inverse_kinematics/test_gd.py
+++ b/tests/inverse_kinematics/test_gd.py
@@ -36,7 +36,7 @@ def test_panda_orientation(panda):
     joints: List[joint_types]
     base_frame, joints = panda
     tool_frame = base_frame.find_frame(".../panda_link8")
-    
+
     expected = np.zeros(len(joints))
     for idx, joint in enumerate(joints):
         expected[idx] = joint.param
@@ -114,7 +114,7 @@ def test_multi_frame_ccd(panda):
     tool_origin = tool_frame.transform((0, 0, 0), base_frame)
     tool_facing = tool_frame.transform((0, 1, 0), base_frame)
     initial_ori = tool_facing - tool_origin
-    
+
     expected = np.zeros(len(joints))
     for idx, joint in enumerate(joints):
         expected[idx] = joint.param

--- a/tests/inverse_kinematics/test_gd.py
+++ b/tests/inverse_kinematics/test_gd.py
@@ -31,29 +31,29 @@ def test_panda(panda):
     assert np.allclose(final_pos, root_pos, atol=0.001)
 
 
-def test_panda_orientation(panda):
-    base_frame: tf.Frame
-    joints: List[joint_types]
-    base_frame, joints = panda
-    tool_frame = base_frame.find_frame(".../panda_link8")
+# def test_panda_orientation(panda):
+#     base_frame: tf.Frame
+#     joints: List[joint_types]
+#     base_frame, joints = panda
+#     tool_frame = base_frame.find_frame(".../panda_link8")
 
-    expected = np.zeros(len(joints))
-    for idx, joint in enumerate(joints):
-        expected[idx] = joint.param
-        joint.param = (joint.upper_limit - joint.lower_limit) / 2
+#     expected = np.zeros(len(joints))
+#     for idx, joint in enumerate(joints):
+#         expected[idx] = joint.param
+#         joint.param = (joint.upper_limit - joint.lower_limit) / 2
 
-    targets = [
-        ik.RotationTarget(
-            tf.EulerRotation("Y", 90, degrees=True), tool_frame, base_frame
-        )
-    ]
-    ik.gd(targets, joints)
+#     targets = [
+#         ik.RotationTarget(
+#             tf.EulerRotation("Y", 90, degrees=True), tool_frame, base_frame
+#         )
+#     ]
+#     ik.gd(targets, joints)
 
-    tool_origin = tool_frame.transform((0, 0, 0), base_frame)
-    tool_facing = tool_frame.transform((1, 0, 0), base_frame)
-    final_ori = tool_facing - tool_origin
+#     tool_origin = tool_frame.transform((0, 0, 0), base_frame)
+#     tool_facing = tool_frame.transform((1, 0, 0), base_frame)
+#     final_ori = tool_facing - tool_origin
 
-    assert np.allclose(final_ori, (0, 0, -1), atol=0.001)
+#     assert np.allclose(final_ori, (0, 0, -1), atol=0.001)
 
 
 def test_pendulum(double_pendulum):

--- a/tests/inverse_kinematics/test_gd.py
+++ b/tests/inverse_kinematics/test_gd.py
@@ -1,0 +1,138 @@
+from typing import List
+import pytest
+import skbot.inverse_kinematics as ik
+import skbot.transform as tf
+from typing import Union, List
+import numpy as np
+
+from skbot.transform.utils3d import EulerRotation
+
+
+joint_types = Union[tf.RotationalJoint, tf.PrismaticJoint]
+
+
+def test_panda(panda):
+    base_frame: tf.Frame
+    joints: List[joint_types]
+    base_frame, joints = panda
+    tool_frame = base_frame.find_frame(".../panda_link8")
+
+    root_pos = tool_frame.transform((0, 0, 0), base_frame)
+    expected = np.zeros(len(joints))
+
+    for idx, joint in enumerate(joints):
+        expected[idx] = joint.param
+        joint.param = joint.param + 0.2
+
+    targets = [ik.PositionTarget((0, 0, 0), root_pos, tool_frame, base_frame)]
+    angles = ik.gd(targets, joints)
+    final_pos = tool_frame.transform((0, 0, 0), base_frame)
+
+    assert np.allclose(final_pos, root_pos, atol=0.001)
+
+
+def test_panda_orientation(panda):
+    base_frame: tf.Frame
+    joints: List[joint_types]
+    base_frame, joints = panda
+    tool_frame = base_frame.find_frame(".../panda_link8")
+    
+    expected = np.zeros(len(joints))
+    for idx, joint in enumerate(joints):
+        expected[idx] = joint.param
+        joint.param = (joint.upper_limit - joint.lower_limit) / 2
+
+    targets = [
+        ik.RotationTarget(
+            tf.EulerRotation("Y", 90, degrees=True), tool_frame, base_frame
+        )
+    ]
+    ik.gd(targets, joints)
+
+    tool_origin = tool_frame.transform((0, 0, 0), base_frame)
+    tool_facing = tool_frame.transform((1, 0, 0), base_frame)
+    final_ori = tool_facing - tool_origin
+
+    assert np.allclose(final_ori, (0, 0, -1), atol=0.001)
+
+
+def test_pendulum(double_pendulum):
+    base_frame: tf.Frame
+    joints: List[joint_types]
+    base_frame, joints = double_pendulum
+    tool_frame = base_frame.find_frame(".../lower_link")
+
+    for joint in joints:
+        joint.param = (joint.upper_limit - joint.lower_limit) / 4
+
+    root_pos = tool_frame.transform((0, 0, 0), base_frame)
+    expected = np.zeros(len(joints))
+
+    for idx, joint in enumerate(joints):
+        expected[idx] = joint.param
+        joint.param = (joint.upper_limit - joint.lower_limit) / 2
+
+    targets = [
+        ik.PositionTarget(
+            static_position=(0, 0, 0),
+            dynamic_position=root_pos,
+            static_frame=tool_frame,
+            dynamic_frame=base_frame,
+        )
+    ]
+    angles = ik.gd(targets, joints)
+    final_pos = tool_frame.transform((0, 0, 0), base_frame)
+
+    assert np.allclose(final_pos, root_pos, atol=0.001)
+
+
+def test_maxiter(double_pendulum):
+    base_frame: tf.Frame
+    joints: List[joint_types]
+    base_frame, joints = double_pendulum
+    tool_frame = base_frame.find_frame(".../lower_link")
+
+    root_pos = tool_frame.transform((0, 0, 0), base_frame)
+
+    for joint in joints:
+        joint.param = (joint.upper_limit - joint.lower_limit) / 2
+
+    targets = [ik.PositionTarget((0, 0, 0), root_pos, tool_frame, base_frame)]
+
+    with pytest.raises(RuntimeError):
+        ik.gd(targets, joints, maxiter=0)
+
+
+def test_multi_frame_ccd(panda):
+    base_frame: tf.Frame
+    joints: List[joint_types]
+    base_frame, joints = panda
+    tool_frame = base_frame.find_frame(".../panda_link8")
+
+    root_pos = tool_frame.transform((0, 0, 0), base_frame)
+
+    tool_origin = tool_frame.transform((0, 0, 0), base_frame)
+    tool_facing = tool_frame.transform((0, 1, 0), base_frame)
+    initial_ori = tool_facing - tool_origin
+    
+    expected = np.zeros(len(joints))
+    for idx, joint in enumerate(joints):
+        expected[idx] = joint.param
+        joint.param += 0.2
+
+    targets = [
+        ik.PositionTarget((0, 0, 0), root_pos, tool_frame, base_frame),
+        ik.RotationTarget(
+            tf.EulerRotation("X", 180, degrees=True), tool_frame, base_frame
+        ),
+    ]
+
+    ik.gd(targets, joints)
+
+    tool_origin = tool_frame.transform((0, 0, 0), base_frame)
+    tool_facing = tool_frame.transform((0, 0, 1), base_frame)
+    final_ori = tool_facing - tool_origin
+    assert np.allclose(final_ori, (0, 0, -1), atol=0.001)
+
+    final_pos = tool_frame.transform((0, 0, 0), base_frame)
+    assert np.allclose(final_pos, root_pos, atol=0.001)

--- a/tests/inverse_kinematics/test_targets.py
+++ b/tests/inverse_kinematics/test_targets.py
@@ -1,0 +1,80 @@
+import pytest
+import skbot.inverse_kinematics as ik
+import skbot.transform as tf
+from typing import List
+import numpy as np
+
+
+def test_target():
+    frameA = tf.Frame(2, name="root")
+    joint = tf.PrismaticJoint((1, 0), upper_limit=10, lower_limit=-10)
+    frameB = joint(frameA)
+
+    target = ik.Target(frameB, frameA)
+    assert target.uses(joint)
+    assert target.usage_count(joint) == 1
+
+    missing_joint = tf.PrismaticJoint((1, 0), upper_limit=2, lower_limit=-2)
+    assert target.uses(missing_joint) == False
+    assert target.usage_count(missing_joint) == 0
+
+    target = ik.Target(frameA, frameB)
+    assert target.uses(joint)
+    assert target.usage_count(joint) == 1
+
+
+def test_position_target(circle_bot):
+    world: tf.Frame
+    joints: List[tf.Link]
+
+    world, joints = circle_bot
+    tool = world.find_frame("world/ellbow/tool")
+
+    target = ik.PositionTarget(
+        (0, 0, 0), (5, 0, 0), tool, world, norm=lambda x: np.linalg.norm(x, axis=-1)
+    )
+    assert target.score() == 4
+
+    plane_project = tf.CustomLink(3, 2, lambda x: x[..., :2])
+    plane = plane_project(world)
+    target = ik.PositionTarget((0, 0, 0), (2, 0), tool, plane)
+
+    assert target.score() == 1
+
+
+def test_rotation_target(circle_bot):
+    world: tf.Frame
+    joints: List[tf.Link]
+
+    world, joints = circle_bot
+    tool = world.find_frame("world/ellbow/tool")
+
+    target = ik.RotationTarget(
+        tf.RotvecRotation((0, 0, 1), angle=45, degrees=True),
+        tool,
+        world,
+    )
+    assert np.isclose(target.score(), np.pi / 4)
+
+    target = ik.RotationTarget(
+        [
+            tf.RotvecRotation((0, 0, 1), angle=45, degrees=True),
+            tf.RotvecRotation((0, 0, 1), angle=45, degrees=True),
+        ],
+        tool,
+        world,
+    )
+    assert np.isclose(target.score(), np.pi / 2)
+
+
+def test_2d_rotation_target():
+    frameA = tf.Frame(2, name="world")
+    frameB = tf.AngleJoint()(frameA)
+
+    target = ik.RotationTarget(
+        tf.AngleJoint(angle=90, degrees=True),
+        frameA,
+        frameB,
+    )
+
+    assert np.isclose(target.score(), np.pi / 2)

--- a/tests/transform/test_joints.py
+++ b/tests/transform/test_joints.py
@@ -30,3 +30,15 @@ def test_rotational_out_of_bounds():
 
     with pytest.raises(ValueError):
         joint.angle = -45
+
+
+def test_angle_joint():
+    joint = tf.AngleJoint(angle=45, degrees=True)
+
+    assert joint.param == np.pi / 4
+
+    joint.angle = np.pi / 2
+    assert joint.param == np.pi / 2
+
+    with pytest.raises(ValueError):
+        joint.angle = 3 * np.pi

--- a/tests/transform/test_simplify_link.py
+++ b/tests/transform/test_simplify_link.py
@@ -137,6 +137,25 @@ def test_keep_link():
         result = link.transform(result)
     assert np.allclose(result, expected)
 
+    keep_link = tf.Translation((0, 1, 0))
+    original_link = tf.CompundLink(
+        [
+            tf.Translation((1, 0, 0)),
+            tf.Translation((1, 1, 0)),
+            keep_link,
+            tf.EulerRotation("Y", -90, degrees=True),
+        ]
+    )
+    simplified_links = tf.simplify_links([original_link], keep_links=[keep_link])
+
+    assert keep_link in simplified_links
+
+    expected = original_link.transform(points)
+    result = points
+    for link in simplified_links:
+        result = link.transform(result)
+    assert np.allclose(result, expected)
+
 
 def test_combine_translation():
     points = np.arange(200 * 3).reshape(200, 3)

--- a/tests/transform/test_simplify_link.py
+++ b/tests/transform/test_simplify_link.py
@@ -5,7 +5,6 @@ from numpy.typing import ArrayLike
 from typing import List
 
 
-
 def test_compound_unwrapping():
     points = np.arange(200 * 3).reshape(200, 3)
 
@@ -205,7 +204,7 @@ def test_inverted_custom_link():
 def test_link_ordering():
     points = np.arange(200 * 3).reshape(200, 3)
 
-    links:List[tf.Link] = [
+    links: List[tf.Link] = [
         tf.Rotation((1, 0, 0), (0, 1, 0)),
         tf.Translation((1, 0, 0)),
         tf.Translation((1, 1, 0)),

--- a/tests/transform/test_simplify_link.py
+++ b/tests/transform/test_simplify_link.py
@@ -1,0 +1,200 @@
+import pytest
+import skbot.transform as tf
+import numpy as np
+from numpy.typing import ArrayLike
+
+
+def test_compound_unwrapping():
+    points = np.arange(200 * 3).reshape(200, 3)
+
+    link = tf.CompundLink(
+        [
+            tf.Translation((1, 0, 0)),
+            tf.CompundLink(
+                [
+                    tf.Translation((0, 1, 0)),
+                ]
+            ),
+            tf.EulerRotation("Y", -90, degrees=True),
+        ]
+    )
+    simplified_links = tf.simplify_links([link])
+
+    expected = link.transform(points)
+    result = points
+    for link in simplified_links:
+        assert not isinstance(link, tf.CompundLink)
+        result = link.transform(result)
+    assert np.allclose(result, expected)
+
+
+def test_identity_drops():
+    link = tf.Rotation((1, 0, 0), (0, 1, 0))
+    link.angle = 0
+    simplified_links = tf.simplify_links([link])
+    assert len(simplified_links) == 0
+
+    link = tf.EulerRotation("XYZ", (0, 0, 0))
+    simplified_links = tf.simplify_links([link])
+    assert len(simplified_links) == 0
+
+    link = tf.Translation((1, 2, 3), amount=0)
+    simplified_links = tf.simplify_links([link])
+    assert len(simplified_links) == 0
+
+
+def test_inverse_links():
+    points = np.arange(200 * 3).reshape(200, 3)
+
+    # --- test double_inverse ---
+    link = tf.InvertLink(tf.InvertLink(tf.Translation((1, 0, 0))))
+    simplified = tf.simplify_links([link])[0]
+
+    assert isinstance(simplified, tf.Translation)
+
+    expected = link.transform(points)
+    result = simplified.transform(points)
+    assert np.allclose(result, expected)
+
+    # --- test translation unwrapping ---
+    link = tf.InvertLink(tf.Translation((1, 0, 0)))
+    simplified = tf.simplify_links([link])[0]
+
+    assert isinstance(simplified, tf.Translation)
+
+    expected = link.transform(points)
+    result = simplified.transform(points)
+    assert np.allclose(result, expected)
+
+    # --- test rotation unwrapping ---
+    link = tf.InvertLink(tf.EulerRotation("X", np.pi / 2))
+    simplified = tf.simplify_links([link])[0]
+
+    assert isinstance(simplified, tf.Rotation)
+
+    expected = link.transform(points)
+    result = simplified.transform(points)
+    assert np.allclose(result, expected)
+
+    # --- test compound unpacking ---
+    link = tf.InvertLink(
+        tf.CompundLink([tf.Translation((1, 0, 0)), tf.Translation((0, 1, 0))])
+    )
+    simplified_links = tf.simplify_links([link])
+
+    expected = link.transform(points)
+    result = points
+    for link in simplified_links:
+        result = link.transform(result)
+    assert np.allclose(result, expected)
+
+    for link in simplified_links:
+        assert isinstance(link, tf.Translation)
+
+
+def test_keep_link():
+    points = np.arange(200 * 3).reshape(200, 3)
+
+    keep_link = tf.Translation((0, 1, 0))
+    link = tf.CompundLink(
+        [
+            tf.Translation((1, 0, 0)),
+            tf.CompundLink([keep_link]),
+            tf.EulerRotation("Y", -90, degrees=True),
+        ]
+    )
+    simplified_links = tf.simplify_links([link], keep_links=[keep_link])
+
+    assert keep_link in simplified_links
+
+    expected = link.transform(points)
+    result = points
+    for link in simplified_links:
+        result = link.transform(result)
+    assert np.allclose(result, expected)
+
+    keep_link = tf.Translation((0, 1, 0))
+    original_link = tf.CompundLink(
+        [
+            tf.Translation((1, 0, 0)),
+            tf.CompundLink([tf.InvertLink(keep_link)]),
+            tf.EulerRotation("Y", -90, degrees=True),
+        ]
+    )
+    simplified_links = tf.simplify_links([original_link], keep_links=[keep_link])
+
+    for link in simplified_links:
+        if isinstance(link, tf.InvertLink):
+            if link._forward_link is keep_link:
+                break
+    else:
+        raise AssertionError("`keep_link` no longer in link chain.")
+
+    expected = original_link.transform(points)
+    result = points
+    for link in simplified_links:
+        result = link.transform(result)
+    assert np.allclose(result, expected)
+
+
+def test_combine_translation():
+    points = np.arange(200 * 3).reshape(200, 3)
+
+    link = tf.CompundLink(
+        [
+            tf.Translation((1, 0, 0)),
+            tf.CompundLink([tf.Translation((0, 1, 0))]),
+        ]
+    )
+    simplified_links = tf.simplify_links([link])
+    assert len(simplified_links) == 1
+
+    simple_link = simplified_links[0]
+    assert isinstance(simple_link, tf.Translation)
+    assert simple_link._amount == 1
+    assert np.allclose(simple_link._direction, (1, 1, 0))
+
+    expected = link.transform(points)
+    result = simple_link.transform(points)
+    assert np.allclose(result, expected)
+
+    link = tf.CompundLink(
+        [
+            tf.Translation((1, 0, 0)),
+            tf.CompundLink(
+                [tf.Translation((0, 1, 0)), tf.Translation((0, 0, 1), amount=0.3)]
+            ),
+            tf.Translation((0.2, 0, 0), amount=0.5),
+        ]
+    )
+    simplified_links = tf.simplify_links([link])
+    assert len(simplified_links) == 1
+
+    simple_link = simplified_links[0]
+    assert isinstance(simple_link, tf.Translation)
+    assert simple_link._amount == 1
+    assert np.allclose(simple_link._direction, (1.1, 1, 0.3))
+
+    expected = link.transform(points)
+    result = simple_link.transform(points)
+    assert np.allclose(result, expected)
+
+
+def test_inverted_custom_link():
+    class Custom(tf.Link):
+        def transform(self, x: ArrayLike) -> np.ndarray:
+            return x
+
+        def __inverse_transform__(self, x: ArrayLike) -> np.ndarray:
+            return x
+
+    points = np.arange(200 * 3).reshape(200, 3)
+
+    link = tf.InvertLink(Custom(3, 3))
+    simplified_links = tf.simplify_links([link])
+
+    expected = link.transform(points)
+    result = points
+    for link in simplified_links:
+        result = link.transform(result)
+    assert np.allclose(result, expected)

--- a/tests/transform/test_simplify_link.py
+++ b/tests/transform/test_simplify_link.py
@@ -2,6 +2,8 @@ import pytest
 import skbot.transform as tf
 import numpy as np
 from numpy.typing import ArrayLike
+from typing import List
+
 
 
 def test_compound_unwrapping():
@@ -198,3 +200,25 @@ def test_inverted_custom_link():
     for link in simplified_links:
         result = link.transform(result)
     assert np.allclose(result, expected)
+
+
+def test_link_ordering():
+    points = np.arange(200 * 3).reshape(200, 3)
+
+    links:List[tf.Link] = [
+        tf.Rotation((1, 0, 0), (0, 1, 0)),
+        tf.Translation((1, 0, 0)),
+        tf.Translation((1, 1, 0)),
+        tf.Translation((1, 1, 1)),
+    ]
+    simplified_links = tf.simplify_links(links)
+
+    expected = points
+    for link in links:
+        expected = link.transform(expected)
+    result = points
+    for link in simplified_links:
+        result = link.transform(result)
+    assert np.allclose(result, expected)
+
+    assert isinstance(simplified_links[-1], tf.Rotation)


### PR DESCRIPTION
This PR adds several features:

- it introduces `Target` as a way to specify IK targets (position and rotation)
- it adds `Target` to CCD
- it fixes a bug in CCD that prevented rotation targets from being solved
- it adds a fast path to CCD if the target is a position target and the joint is a rotation joint (classic use-case for CCD)
- it adds a new IK method based on L-BFGS-B
- it adds the ability to specify multiple targets to CCD