### PR TITLE
FEAT: Common joint class

### DIFF
--- a/skbot/inverse_kinematics/cyclic_coordinate_descent.py
+++ b/skbot/inverse_kinematics/cyclic_coordinate_descent.py
@@ -6,17 +6,16 @@ import numpy as np
 from scipy.optimize import minimize_scalar
 from scipy.optimize import OptimizeResult
 from .targets import Target, PositionTarget, RotationTarget
-from .types import IKJoint
 
 import warnings
 
 
 def step_generic_joint(
-    joint: IKJoint, target: Target, maxiter: int
+    joint: tf.Joint, target: Target, maxiter: int
 ) -> Callable[[], None]:
     """Find the optimal value for the current joint."""
 
-    def generic_objective(x: float, current_joint: IKJoint) -> float:
+    def generic_objective(x: float, current_joint: tf.Joint) -> float:
         current_joint.param = x
         return target.score()
 
@@ -104,14 +103,14 @@ def analytic_rotation(
 
 def ccd(
     targets: List[Target],
-    joints: List[IKJoint] = None,
+    joints: List[tf.Joint] = None,
     *args,
     rtol: float = 1e-6,
     maxiter: int = 500,
     line_search_maxiter: int = 500,
     weights: List[float] = None,
     tol: float = None,
-    cycle_links: List[IKJoint] = None,
+    cycle_links: List[tf.Joint] = None,
     pointA: ArrayLike = None,
     pointB: ArrayLike = None,
     frameA: tf.Frame = None,
@@ -155,7 +154,7 @@ def ccd(
             Targets are optimized cyclical instead of optimizing a weighted sum.
 
         This parameter has no effect.
-    cycle_links : List[IKJoint]
+    cycle_links : List[tf.Joint]
         .. deprecated:: 0.10.0
             Use ``joints`` instead.
 
@@ -221,7 +220,7 @@ def ccd(
 
     References
     ----------
-    .. [kenwright2012] Kenwright, Ben. "Inverse kinematics–cyclic coordinate descent (CCD)."
+    .. [kenwright2012] Kenwright, Ben. "Inverse kinematics-cyclic coordinate descent (CCD)."
         Journal of Graphics Tools 16.4 (2012): 177-217.
 
     """

--- a/skbot/inverse_kinematics/gradient_descent.py
+++ b/skbot/inverse_kinematics/gradient_descent.py
@@ -2,14 +2,13 @@ from .. import transform as tf
 from .targets import Target
 from typing import List
 import numpy as np
-from .types import IKJoint
 from scipy.optimize import minimize, OptimizeResult, Bounds
 import warnings
 
 
 def gd(
     targets: List[Target],
-    joints: List[IKJoint],
+    joints: List[tf.Joint],
     *,
     rtol: float = 1e-6,
     maxiter: int = 500,

--- a/skbot/inverse_kinematics/types.py
+++ b/skbot/inverse_kinematics/types.py
@@ -1,5 +1,0 @@
-from typing import Union
-
-from .. import transform as tf
-
-IKJoint = Union[tf.PrismaticJoint, tf.RotationalJoint]

--- a/skbot/transform/__init__.py
+++ b/skbot/transform/__init__.py
@@ -93,6 +93,47 @@ Available Transformations
     CompundLink
     InvertLink
 
+Joints
+------
+
+Joints are a special subclass of links. On top of normal links, they are bounded, i.e. they have
+an ``upper_limit`` and a ``lower_limit``, and their value can be accessed by the common name ``param``.
+For example::
+
+    import skbot.transform as tf
+    import numpy as np
+
+    joint = tf.AngleJoint()
+    assert joint.param == joint.angle
+    assert joint.lower_limit == 0
+    assert joint.upper_limit == 2 * np.pi
+
+    # setting param affects the angle
+    joint.param = np.pi
+    assert joint.angle == np.pi
+
+.. rubric:: Available Joints
+
+.. autosummary::
+    
+    RotationalJoint
+    PrismaticJoint
+    AngleJoint
+
+.. rubric:: Custom Joints
+
+You can create your own joints by inheriting from :class:`tf.Link
+<skbot.transform.Link>` (to make the class a link) and from ``tf.Joint`` (to
+mark the class as a joint)::
+
+    class CustomJoint(tf.Link, tf.Joint):
+        ...
+
+        # Make sure to implement the required properties: 
+        # param, lower_limit, upper_limit
+        # and to implement a setter for param
+
+
 Functions
 ---------
 
@@ -129,7 +170,7 @@ from .utils3d import (
     QuaternionRotation,
     RotvecRotation,
 )
-from .joints import RotationalJoint, PrismaticJoint, AngleJoint
+from .joints import RotationalJoint, PrismaticJoint, AngleJoint, Joint
 
 from . import metrics
 from .simplfy import simplify_links
@@ -158,6 +199,7 @@ __all__ = [
     "InvertLink",
     "CompundLink",
     "Inverse",
+    "Joint",
     # basic transformation functions
     "translate",
     "rotate",

--- a/skbot/transform/base.py
+++ b/skbot/transform/base.py
@@ -614,6 +614,76 @@ class Frame:
 
         return frames
 
+    def joints_between(
+        self,
+        to_frame: Union["Frame", str],
+        *,
+        ignore_frames: List["Frame"] = None,
+        metric: Callable[[Tuple["Frame"], Tuple[Link]], float] = DepthFirst,
+        max_depth: int = None,
+    ):
+        """Get the links between this frame and ``to_frame``.
+
+        .. versionadded:: 0.12.0
+
+        This function searches the frame graph for a chain of transformations
+        from the current frame into ``to_frame`` and returns the sequence of
+        joints involved in this transformation. All joints will be "unwraped",
+        i.e., if a Joint occurs inside a :class:`tf:InvertLink` or similar, then
+        only the Joint will be returned. The resulting order matches the order
+        that links are encountered in the transformation chain.
+
+        Parameters
+        ----------
+        to_frame : Frame, str
+            The frame in which to express vectors. If ``str``, the graph is
+            searched for any node matching that name and the transformation
+            chain to the first node matching the name is returned.
+        ignore_frames : List[Frame]
+            A list of frames to exclude while searching for a transformation
+            chain.
+        metric : Callable[[Tuple[Frame], Tuple[Link]], float]
+            A function to compute the priority of a sub-chain. Sub-chains are
+            searched in order of priority starting with the lowest value. The
+            first chain that matches ``to_frame`` is returned. You can use a
+            custom function that takes a sequence of frames and links involved
+            in the sub-chain as input and returns a float (signature
+            ``custom_fn(frames, links) -> float``), or you can use a pre-build
+            function:
+
+                skbot.transform.metric.DepthFirst
+                    The frame graph is searched depth-first with no
+                    preference among frames (default).
+                skbot.transform.metric.BreadthFirst
+                    The frame graph is searched breadth-first with no
+                    preference among frames.
+        max_depth : int
+            If not None, the maximum depth to search, i.e., the maximum length
+            of the transform chain.
+
+        """
+
+        # avoid circular import
+        from .simplfy import simplify_links
+        from .joints import Joint
+
+        links = self.links_between(
+            to_frame, ignore_frames=ignore_frames, metric=metric, max_depth=max_depth
+        )
+
+        # unwrap and summarize what we can
+        links = simplify_links(links)
+
+        # unwrap inverse links
+        links = [
+            link._forward_link if isinstance(link, InvertLink) else link
+            for link in links
+        ]
+
+        joints = [link for link in links if isinstance(link, Joint)]
+
+        return joints
+
     def find_frame(self, path: str, *, ignore_frames: List["Frame"] = None) -> "Frame":
         """Find a frame matching a given path.
 

--- a/skbot/transform/base.py
+++ b/skbot/transform/base.py
@@ -672,7 +672,7 @@ class Frame:
         )
 
         # unwrap and summarize what we can
-        links = simplify_links(links)
+        links = simplify_links(links, keep_joints=True)
 
         # unwrap inverse links
         links = [

--- a/skbot/transform/simplfy.py
+++ b/skbot/transform/simplfy.py
@@ -9,7 +9,7 @@ def simplify_links(
     links: List[Link],
     *,
     keep_links: List[Link] = None,
-    keep_joints: bool = True,
+    keep_joints: bool = False,
     eps: float = 1e-16
 ) -> List[Link]:
     """Simplify a transformation sequence.
@@ -37,7 +37,7 @@ def simplify_links(
     keep_links : List[Link]
         A list list of links that - if present - should not be simplified.
     keep_joints : bool
-        If True (default) don't replace tf.Joint instances.
+        If True treat tf.Joint instances as if they were in keep_links.
     eps : float
         The number below which angles and translations are interpreted as 0.
         Defaults to ``1e-16``.

--- a/skbot/transform/simplfy.py
+++ b/skbot/transform/simplfy.py
@@ -1,11 +1,16 @@
 from typing import List
 from .base import CompundLink, Link, InvertLink
 from .affine import AffineCompound, Translation, Rotation
+from .joints import Joint
 import numpy as np
 
 
 def simplify_links(
-    links: List[Link], *, keep_links: List[Link] = None, eps: float = 1e-16
+    links: List[Link],
+    *,
+    keep_links: List[Link] = None,
+    keep_joints: bool = True,
+    eps: float = 1e-16
 ) -> List[Link]:
     """Simplify a transformation sequence.
 
@@ -31,6 +36,8 @@ def simplify_links(
         The list of links to simplify.
     keep_links : List[Link]
         A list list of links that - if present - should not be simplified.
+    keep_joints : bool
+        If True (default) don't replace tf.Joint instances.
     eps : float
         The number below which angles and translations are interpreted as 0.
         Defaults to ``1e-16``.
@@ -51,7 +58,7 @@ def simplify_links(
             link = links[idx]
 
             # skip if link should not be modified
-            if link in keep_links:
+            if link in keep_links or (isinstance(link, Joint) and keep_joints):
                 improved_links.append(link)
                 continue
 
@@ -60,7 +67,9 @@ def simplify_links(
                 inverted_link = link._forward_link
 
                 # still don't touch keep links
-                if inverted_link in keep_links:
+                if inverted_link in keep_links or (
+                    isinstance(inverted_link, Joint) and keep_joints
+                ):
                     improved_links.append(link)
                     continue
 
@@ -177,7 +186,7 @@ def simplify_links(
     keepsies: List[Link] = list()
     current_subchain: List[Link] = list()
     for link in improved_links:
-        if link in keep_links:
+        if link in keep_links or (isinstance(link, Joint) and keep_joints):
             keepsies.append(link)
             subchains.append(current_subchain)
             current_subchain = list()

--- a/tests/inverse_kinematics/test_ccd.py
+++ b/tests/inverse_kinematics/test_ccd.py
@@ -5,13 +5,12 @@ import skbot.transform as tf
 import skbot.ignition as ign
 from typing import List
 import numpy as np
-from skbot.inverse_kinematics.types import IKJoint as joint_types
 from pathlib import Path
 
 
 def test_panda(panda):
     base_frame: tf.Frame
-    joints: List[joint_types]
+    joints: List[tf.Joint]
     base_frame, joints = panda
     tool_frame = base_frame.find_frame(".../panda_link8")
 
@@ -32,7 +31,7 @@ def test_panda(panda):
 
 def test_panda_orientation(panda):
     base_frame: tf.Frame
-    joints: List[joint_types]
+    joints: List[tf.Joint]
     base_frame, joints = panda
     tool_frame = base_frame.find_frame(".../panda_link8")
 
@@ -59,7 +58,7 @@ def test_panda_orientation(panda):
 
 def test_custom_distance(panda):
     base_frame: tf.Frame
-    joints: List[joint_types]
+    joints: List[tf.Joint]
     base_frame, joints = panda
     tool_frame = base_frame.find_frame(".../panda_link8")
 
@@ -91,7 +90,7 @@ def test_custom_distance(panda):
 
 def test_pendulum(double_pendulum):
     base_frame: tf.Frame
-    joints: List[joint_types]
+    joints: List[tf.Joint]
     base_frame, joints = double_pendulum
     tool_frame = base_frame.find_frame(".../lower_link")
 
@@ -121,7 +120,7 @@ def test_pendulum(double_pendulum):
 
 def test_pendulum_legacy(double_pendulum):
     base_frame: tf.Frame
-    joints: List[joint_types]
+    joints: List[tf.Joint]
     base_frame, joints = double_pendulum
     tool_frame = base_frame.find_frame(".../lower_link")
 
@@ -143,7 +142,7 @@ def test_pendulum_legacy(double_pendulum):
 
 def test_pendulum_legacy_kwargs(double_pendulum):
     base_frame: tf.Frame
-    joints: List[joint_types]
+    joints: List[tf.joint]
     base_frame, joints = double_pendulum
     tool_frame = base_frame.find_frame(".../lower_link")
 
@@ -174,7 +173,7 @@ def test_pendulum_legacy_kwargs(double_pendulum):
 
 def test_ccd_maxiter(double_pendulum):
     base_frame: tf.Frame
-    joints: List[joint_types]
+    joints: List[tf.joint]
     base_frame, joints = double_pendulum
     tool_frame = base_frame.find_frame(".../lower_link")
 
@@ -191,7 +190,7 @@ def test_ccd_maxiter(double_pendulum):
 
 def test_ccd_linesearch_maxiter(panda):
     base_frame: tf.Frame
-    joints: List[joint_types]
+    joints: List[tf.joint]
     base_frame, joints = panda
     tool_frame = base_frame.find_frame(".../panda_link8")
 
@@ -215,7 +214,7 @@ def test_ccd_linesearch_maxiter(panda):
 # # Multi-Frame (pos+rot) doesn't work with CCD (yet?)
 # def test_multi_frame_ccd(panda):
 #     base_frame: tf.Frame
-#     joints: List[joint_types]
+#     joints: List[tf.joint]
 #     base_frame, joints = panda
 #     tool_frame = base_frame.find_frame(".../panda_link8")
 

--- a/tests/transform/test_base.py
+++ b/tests/transform/test_base.py
@@ -111,6 +111,26 @@ def test_named_links_between():
     assert len(elements) == 3
 
 
+def test_joints_between():
+    joint1 = tf.RotationalJoint((0, 1, 0))
+    joint2 = tf.PrismaticJoint((1, 0, 0))
+
+    start = tf.Frame(3)
+    x = tf.Rotation((1, 0, 0), (0, 1, 0))(start)
+    x = tf.Translation((1, 0, 0))(x)
+    x = joint1(x)
+    x = tf.CompundLink(
+        [joint2, tf.EulerRotation("xy", (90, -90), degrees=True), joint1]
+    )(x)
+    x = tf.Translation((1, 1, 0))(x)
+    x = tf.Translation((1, 1, 1))(x)
+    end = tf.InvertLink(joint2)(x)
+
+    joints = start.joints_between(end)
+
+    assert joints == [joint1, joint2, joint1, joint2]
+
+
 def test_inverse_attributes():
     link = tf.Translation((1, 0), amount=0.5)
     inv_link = tf.InvertLink(link)

--- a/tests/transform/test_simplify_link.py
+++ b/tests/transform/test_simplify_link.py
@@ -240,3 +240,31 @@ def test_link_ordering():
     assert np.allclose(result, expected)
 
     assert isinstance(simplified_links[-1], tf.Rotation)
+
+
+def test_keep_joints():
+    points = np.arange(200 * 3).reshape(200, 3)
+
+    joint1 = tf.RotationalJoint((0, 1, 0))
+    joint2 = tf.PrismaticJoint((1, 0, 0))
+
+    links: List[tf.Link] = [
+        tf.Rotation((1, 0, 0), (0, 1, 0)),
+        tf.Translation((1, 0, 0)),
+        joint1,
+        tf.Translation((1, 1, 0)),
+        tf.Translation((1, 1, 1)),
+        tf.InvertLink(joint2),
+    ]
+    simplified_links = tf.simplify_links(links)
+
+    expected = points
+    for link in links:
+        expected = link.transform(expected)
+    result = points
+    for link in simplified_links:
+        result = link.transform(result)
+    assert np.allclose(result, expected)
+
+    assert joint1 in simplified_links
+    assert joint2 is simplified_links[-1]._forward_link

--- a/tests/transform/test_simplify_link.py
+++ b/tests/transform/test_simplify_link.py
@@ -256,7 +256,7 @@ def test_keep_joints():
         tf.Translation((1, 1, 1)),
         tf.InvertLink(joint2),
     ]
-    simplified_links = tf.simplify_links(links)
+    simplified_links = tf.simplify_links(links, keep_joints=True)
 
     expected = points
     for link in links:


### PR DESCRIPTION
This PR adds:

- A abstract `tf.Joint` class that all joints subclass via multiple inheritance
- a refactor of the ik module to make use of tf.Joint
- a new kwarg for tf.simplify called `keep_joints=False`, which if true will treat joints to keep_links
- a new method for tf.Frame called `joints_between`, which returns a list of joints between two frames in a frame graph.