### PR TITLE
FEAT: hexagon coordinate round

### DIFF
--- a/examples/plot_hexagonal_grids.py
+++ b/examples/plot_hexagonal_grids.py
@@ -1,0 +1,74 @@
+""" 
+
+Working with a Hexagonal Grid
+=============================
+
+This example showcases one of the more esoteric features of scikit-bot's
+transformation library: transformation to and from hexagonal coordinate systems. 
+
+Why would you want to use hexagonal coordinates? Various reasons: Firstly, they
+are useful in imaging applications, because they provide better sampling
+efficiency than their square-shaped alternative. Secondly, they are useful for
+occupancy grids because neighbouring elements have the same distance from each
+other. Finally, they look really cool and make for nice visualizations in a
+paper.
+
+"""
+
+import numpy as np
+import skbot.transform as tf
+import matplotlib.pyplot as plt
+import matplotlib
+
+cmap = matplotlib.cm.get_cmap("tab10")
+
+# %%
+# There is two parts to using them: Firstly there is
+# :class:`tf.AxialHexagonTransform <skbot.transform.AxialHexagonTransform>`,
+# which transforms 2D cartesian coordinates into hexagonal coordinates. Here are
+# a few examples::
+#
+#    tf.AxialHexagonTransform()
+#    tf.AxialHexagonTransform(size=4)  # a hex grid with larger hexagons
+#    tf.AxialHexagonTransform(flat_top=False)  # a hex grid that is rotated by 90 degrees
+#
+# When you use this transformation, the result will be a continous value, which
+# is useful because it keeps all information and can be inverted to go back to
+# cartesian coordinates. However, often you want to know which hexagon a
+# coordinate falls into, which is where :class:`tf.HexagonAxisRound
+# <skbot.transform.HexagonAxisRound>` comes in. As the name suggests, it will
+# round a vector in hexagon coordinates to the closest hexagon.
+#
+# We can use this, for example, to perform rejection sampling on the hexagon grid:
+
+to_hex = tf.AxialHexagonTransform()
+from_hex = tf.InvertLink(to_hex)
+
+# a 3x3 hex grid (because we can use a nice colormap in this case)
+grid = np.stack(np.meshgrid(np.arange(3), np.arange(3)), axis=-1)
+hex_centers = from_hex.transform(grid)
+
+sampling_rectangle = [-1, -1, 7, 5]
+x, y, w, h = [-1, -1, 7, 5]
+candidate_points = np.random.rand(150, 2) * (h, w) + (y, x)
+hex_points = to_hex.transform(candidate_points)
+hex_points_rounded = tf.HexagonAxisRound().transform(hex_points)
+is_in_hexagon = np.all(np.isin(hex_points_rounded, [0, 1, 2]), axis=1)
+points = candidate_points[is_in_hexagon, :]  # points are rejected here
+
+# %%
+# We can also use :class:`tf.HexagonAxisRound
+# <skbot.transform.HexagonAxisRound>` to figure out which hexagon a sampled
+# point fell into, and then use that information to label the sampled point:
+
+hex_points = to_hex.transform(points)
+hex_points_rounded = tf.HexagonAxisRound().transform(hex_points)
+col_idx = np.ravel_multi_index(tuple(hex_points_rounded[:, ::-1].T.astype(int)), (3, 3))
+
+plt.scatter(points[..., 1], points[..., 0], marker="s", c=cmap(col_idx))
+plt.scatter(hex_centers[..., 1], hex_centers[..., 0], c=cmap(np.arange(9)), s=150)
+for pos in hex_centers.reshape(-1, 2):
+    patch = matplotlib.patches.RegularPolygon(
+        (pos[1], pos[0]), numVertices=6, radius=1, alpha=0.2, edgecolor="k"
+    )
+    plt.gca().add_patch(patch)

--- a/examples/plot_hexagonal_grids.py
+++ b/examples/plot_hexagonal_grids.py
@@ -63,7 +63,7 @@ points = candidate_points[is_in_hexagon, :]  # points are rejected here
 
 hex_points = to_hex.transform(points)
 hex_points_rounded = tf.HexagonAxisRound().transform(hex_points)
-col_idx = np.ravel_multi_index(tuple(hex_points_rounded[:, ::-1].T.astype(int)), (3, 3))
+col_idx = np.ravel_multi_index(tuple(hex_points_rounded[:, ::-1].T), (3, 3))
 
 plt.scatter(points[..., 1], points[..., 0], marker="s", c=cmap(col_idx))
 plt.scatter(hex_centers[..., 1], hex_centers[..., 0], c=cmap(np.arange(9)), s=150)

--- a/skbot/transform/__init__.py
+++ b/skbot/transform/__init__.py
@@ -84,6 +84,7 @@ Available Transformations
     Rotation2D
     AngleJoint
     AxialHexagonTransform
+    HexagonAxisRound
 
 .. rubric:: Other Links
 
@@ -173,7 +174,7 @@ from .utils3d import (
     RotvecRotation,
 )
 from .joints import RotationalJoint, PrismaticJoint, AngleJoint, Joint
-from .utils2d import AxialHexagonTransform, Rotation2D
+from .utils2d import AxialHexagonTransform, Rotation2D, HexagonAxisRound
 
 from . import metrics
 from .simplfy import simplify_links
@@ -192,6 +193,7 @@ __all__ = [
     "AngleJoint",
     "AxialHexagonTransform",
     "Rotation2D",
+    "HexagonAxisRound",
     # 3D Links
     "EulerRotation",
     "QuaternionRotation",

--- a/skbot/transform/utils2d.py
+++ b/skbot/transform/utils2d.py
@@ -151,7 +151,7 @@ class HexagonAxisRound(Link):
         cube_coordinates = cube_coordinates.reshape(-1, 3)
 
         # round and enforce q+r+s=0 constraint
-        cube_rounded = np.round(cube_coordinates)
+        cube_rounded = np.round(cube_coordinates).astype(int)
         residual = np.abs(cube_coordinates - cube_rounded)
         first_max = np.argmax(residual, axis=-1)
         matching_range = np.arange(first_max.shape[0])

--- a/tests/transform/test_utils2d.py
+++ b/tests/transform/test_utils2d.py
@@ -107,3 +107,41 @@ def test_axisHex():
     assert np.allclose(actual, expected)
     actual = hex_transform.transform(actual)
     assert np.allclose(actual, hex_coords)
+
+
+def test_hexagonal_rounding():
+    points = np.array(
+        [
+            [1.52995404, 1.66930696],
+            [3.57505867, 5.779062],
+            [3.01175057, 3.25270593],
+            [1.77169734, 0.75625665],
+            [0.86887117, 3.50156075],
+            [3.00158257, 4.4222308],
+            [0.67052669, 4.51412333],
+            [-0.46998425, 2.20315508],
+            [2.28559953, 1.5207328],
+            [-0.85131309, 3.39568141],
+        ]
+    )
+
+    expected = np.array(
+        [
+            [1.0, 0.0],
+            [2.0, 2.0],
+            [2.0, 1.0],
+            [1.0, -0.0],
+            [0.0, 2.0],
+            [2.0, 2.0],
+            [1.0, 2.0],
+            [-0.0, 1.0],
+            [2.0, 0.0],
+            [0.0, 2.0],
+        ]
+    )
+
+    to_hex = tf.AxialHexagonTransform()
+    hex_points = to_hex.transform(points)
+    hex_points_rounded = tf.HexagonAxisRound().transform(hex_points)
+
+    assert np.allclose(hex_points_rounded, expected)


### PR DESCRIPTION
Adds the ability to round vectors in hexagon coordinates to the nearest hexagon.